### PR TITLE
[ENHANCE] Support modern forward slash comments

### DIFF
--- a/src/blitzrc/compiler/toker.cpp
+++ b/src/blitzrc/compiler/toker.cpp
@@ -205,6 +205,9 @@ void Toker::nextline(){
 			continue;
 		}
 		if( c==';' || (c=='/' && line[k+1]=='/' ) ){
+			if (c==';') {
+				cout << "WARNING (" << curr_row << ", " << k << "): Semicolon line comments are deprecated. Use '//' instead." << endl;
+			}
 			for( ++k;line[k]!='\n';++k ){}
 			continue;
 		}

--- a/src/blitzrc/compiler/toker.cpp
+++ b/src/blitzrc/compiler/toker.cpp
@@ -179,6 +179,7 @@ void Toker::nextline(){
 			originalLine.clear();
 			line.resize(1);line[0]=EOF;
 			tokes.push_back( Toke( EOF,0,1 ) );
+			in_comment=false;
 			return;
 		}
 		getline( in,line ); line+='\n';
@@ -194,7 +195,16 @@ void Toker::nextline(){
 			continue;
 		}
 		if( isspace( c ) ){ ++k;continue; }
-		if( c==';' ){
+		if ((c=='/' && line[k+1]=='*') || in_comment) {
+			in_comment=true;
+			for( ++k;line[k]!='\n';++k ){
+				if (line[k]=='*' && line[k+1]=='/') {
+					in_comment=false;
+				}
+			}
+			continue;
+		}
+		if( c==';' || (c=='/' && line[k+1]=='/' ) ){
 			for( ++k;line[k]!='\n';++k ){}
 			continue;
 		}

--- a/src/blitzrc/compiler/toker.h
+++ b/src/blitzrc/compiler/toker.h
@@ -73,6 +73,7 @@ private:
 	vector<Toke> tokes;
 	void nextline();
 	int curr_row,curr_toke;
+	bool in_comment=false;
 
 	int process_injected=0;
 	vector<string> line_cache;

--- a/tests/ExampleTest.bb
+++ b/tests/ExampleTest.bb
@@ -1,7 +1,16 @@
 Strict
 EnableGC
 
-; This is a test of the Test block
+; This is a test semicolon line comment
+// This is a test line comment
+
+/**
+ * This is a test of the block comment
+ * @param test
+ * @return test
+ * @author test
+ * @deprecated 
+**/
 
 Test test1()
     ;Assert(0) ; Fail

--- a/tests/MathsTest.bb
+++ b/tests/MathsTest.bb
@@ -1,0 +1,19 @@
+Strict
+EnableGC
+
+Test AdditionTest()
+    Assert( 1 + 1 = 2 )
+End Test
+
+Test SubtractionTest()
+    Assert( 2 - 1 = 1 )
+End Test
+
+Test MultiplicationTest()
+    Assert( 2 * 2 = 4 )
+End Test
+
+Test DivisionTest()
+    Assert( 4 / 2 = 2 )
+End Test
+


### PR DESCRIPTION
This PR adds support for the modern `//` line comments and also the `/* */` block comment style.

A deprecation warning has been added for `;` semicolon comments as these will be removed in a future version.

This supports our endeavor in the discussion item #1 