### PR TITLE
[ENHANCE] Allow methods to be called dynamically from instances

### DIFF
--- a/src/blitzrc/compiler/exprnode.cpp
+++ b/src/blitzrc/compiler/exprnode.cpp
@@ -191,11 +191,57 @@ void ExprSeqNode::castTo( Type *t,Environ *e ){
 ///////////////////
 ExprNode *CallNode::semant( Environ *e ){
 	Type *t=e->findType( tag );
-	sem_decl=e->findFunc( ident );
-	if( !sem_decl || !(sem_decl->kind & DECL_FUNC) ) ex( "Function '"+ident+"' not found" );
+	exprs->semant( e );
+
+	// Check if the function was a method call
+	if (ident.find("::") == 0) {
+		// Get the first argument of the call
+		ExprNode* node = exprs->exprs.at(0);
+		VarExprNode* varNode = dynamic_cast<VarExprNode*>(node);
+		if (varNode) {
+			// Get the struct type of the first argument
+			StructType* structType = varNode->var->sem_type->structType();
+			if (structType) {
+				// If the struct type is found, check if the method exists in the struct
+				string originalTypeIdent = structType->ident;
+				string typeIdent = originalTypeIdent;
+
+				// If it doesn't exist, check if it exists in the next struct in the inheritance hierarchy
+				while (!e->findFunc(typeIdent + ident)) {
+					// If the struct type is the last in the hierarchy, break
+					if (structType->tag.empty()) {
+						break;
+					}
+
+					// Get the next struct in the hierarchy
+					Type* type = e->findType(structType->tag);
+					if (type == nullptr || type == 0 || !type->structType()) {
+						break;
+					}
+					structType = type->structType();
+					typeIdent = structType->ident;
+				}
+
+				// If method was found in the inheritance hierarchy, set the ident to the static type ident + method name
+				sem_decl=e->findFunc( typeIdent + ident );
+				if (!sem_decl || !(sem_decl->kind & DECL_FUNC)) {
+					ex("Method '" + ident.substr(2) + "' not found in '" + originalTypeIdent + "'");
+				}
+				ident = typeIdent + ident;
+			} else {
+				ex("Unable to resolve method '" + ident.substr(2) + "'");
+			}
+		} else {
+			ex("Unable to resolve method '" + ident.substr(2) + "'");
+		}
+	} else {
+		sem_decl=e->findFunc( ident );
+		if( !sem_decl || !(sem_decl->kind & DECL_FUNC) ) ex( "Function '"+ident+"' not found" );
+	}
+	
 	FuncType *f=sem_decl->type->funcType();
 	if( t && f->returnType!=t ) ex( "incorrect function return type" );
-	exprs->semant( e );
+	
 	exprs->castTo( f->params,e,f->cfunc );
 	sem_type=f->returnType;
 	return this;

--- a/src/blitzrc/compiler/parser.cpp
+++ b/src/blitzrc/compiler/parser.cpp
@@ -220,15 +220,58 @@ void Parser::parseStmtSeq( StmtSeqNode *stmts,int scope ){
 					if (strictMode && toker->curr()=='\\') {
 						isField = true;
 					}
-					a_ptr<VarNode> var( parseVar( ident,tag ) );
-					if (strictMode) {
-						bool isGlobal = std::find(globalIdents.begin(), globalIdents.end(), ident) != globalIdents.end();
-						bool isLocal = std::find(stmts->localIdents.begin(), stmts->localIdents.end(), ident) != stmts->localIdents.end();
-						if (!isField && !isGlobal && !isLocal) ex( ident + " assignment should start with local, global or const modifier");
+					
+					if( toker->lookAhead(2)=='(' && isField) {
+						toker->next();
+						// Must be a method call// Get method name
+						string methodName = toker->text();
+						toker->next();
+
+						ExprSeqNode *exprs;
+						if (toker->curr()!='(') exp( "variable assignment or method call" );
+
+						int nest=1,k;
+						for( k=1;;++k ){
+							int c=toker->lookAhead( k );
+							if( isTerm( c ) ) ex( "Mismatched brackets" );
+							else if( c=='(' ) ++nest;
+							else if( c==')' && !--nest ) break;
+						}
+
+						if( isTerm( toker->lookAhead( ++k ) ) ){
+							// Use the ident as the first argument of the call
+							string selfInject = ident;
+							if( toker->lookAhead(1)!=')' ) selfInject = ident + ',';
+
+							toker->inject(selfInject);
+							toker->next();
+
+							exprs=parseExprSeq();
+							if( toker->curr()!=')' ) exp( "')'" );
+							toker->next();
+						}else {
+							// Use the ident as the first argument of the call
+							string selfInject = ident;
+							if( toker->lookAhead(1)!=')' ) selfInject = ident + ',';
+
+							toker->inject(selfInject);
+							toker->next();
+
+							exprs=parseExprSeq();
+						}
+						CallNode *call=d_new CallNode( "::" + methodName,tag,exprs );
+						result=d_new ExprStmtNode( call );
+					} else {
+						a_ptr<VarNode> var( parseVar( ident,tag ) );
+						if (strictMode) {
+							bool isGlobal = std::find(globalIdents.begin(), globalIdents.end(), ident) != globalIdents.end();
+							bool isLocal = std::find(stmts->localIdents.begin(), stmts->localIdents.end(), ident) != stmts->localIdents.end();
+							if (!isField && !isGlobal && !isLocal) ex( ident + " assignment should start with local, global or const modifier");
+						}
+						if (toker->curr()!='=') exp( "variable assignment" );
+						toker->next();ExprNode *expr=parseExpr( false );
+						result=d_new AssNode( var.release(),expr );
 					}
-					if( toker->curr()!='=' ) exp( "variable assignment" );
-					toker->next();ExprNode *expr=parseExpr( false );
-					result=d_new AssNode( var.release(),expr );
 				}
 			}
 			break;

--- a/tests/MethodTest.bb
+++ b/tests/MethodTest.bb
@@ -8,14 +8,37 @@ Type TestStruct
     End Method
 End Type
 
+Type SecondStruct.TestStruct
+
+End Type
+
+Type ThirdStruct.TestStruct
+    Method testMethod(testArg$)
+        self\testVar = "pre" + testArg$
+    End Method
+End Type
+
+Type FourthStruct.ThirdStruct
+
+End Type
+
+
 Test testMutation()
     Local testType1.TestStruct = new TestStruct()
 
-    testType1\testVar = "initial set"
+    testType1\testVar = "foo"
 
-    TestStruct::testMethod(testType1,"reset")
+    // You can either call the method as static
+    TestStruct::testMethod(testType1,"bar")
 
-    Assert(testType1\testVar = "reset")
+    Assert(testType1\testVar = "bar")
+
+    testType1\testVar = "fizz"
+
+    // Or dynamic
+    testType1\testMethod("buzz")
+
+    Assert(testType1\testVar = "buzz")
 End Test
 
 ;Function m::func() ; This fails so that we don't overwrite exisiting type functions
@@ -42,4 +65,28 @@ End Test
 Test testNullTypeAccess()
     Local instance.TestStruct = Null
     ;instance\testVar = "" ; Fail
+End Test
+
+Test testMethodInherit()
+    local instance.SecondStruct = new SecondStruct()
+    instance\testVar = "foo"
+    instance\testMethod("bar")
+
+    Assert(instance\testVar = "bar")
+End Test
+
+Test testMethodOverride()
+    local instance.ThirdStruct = new ThirdStruct()
+    instance\testVar = "foo"
+    instance\testMethod("bar")
+
+    Assert(instance\testVar = "prebar")
+End Test
+
+Test testMethodOverrideInherit()
+    local instance.FourthStruct = new FourthStruct()
+    instance\testVar = "foo"
+    instance\testMethod("bar")
+
+    Assert(instance\testVar = "prebar")
 End Test


### PR DESCRIPTION
This PR enables the ability to call any method within a types inheritance from an instance of that type. The convention is similar to how fields are accessed.

`instance\method(arg)`

While the static call convention is still supported this is a much better way to go about this.