### PR TITLE
[FIX] Avoid loading duplicate userlib decls

### DIFF
--- a/src/blitzrc/blitz/libs.cpp
+++ b/src/blitzrc/blitz/libs.cpp
@@ -153,6 +153,31 @@ static const char *linkRuntime(){
 
 static set<string> _ulibkws;
 
+static string normalizeUserLibDir( const string &path ){
+	string t=bfplatform::normalizeIncludeCachePath( path );
+	while( t.size()>1 && (t[t.size()-1]=='/' || t[t.size()-1]=='\\') ) t.resize( t.size()-1 );
+	return t;
+}
+
+static vector<string> userLibSearchPaths( const char *cwd ){
+	vector<string> paths;
+	paths.push_back( home+"/../userlibs/" );
+	if( cwd && *cwd ){
+		paths.push_back( string(cwd)+"/userlibs/" );
+		paths.push_back( string(cwd)+"/../userlibs/" );
+	}
+
+	set<string> seen;
+	vector<string> unique;
+
+	for( vector<string>::const_iterator it=paths.begin();it!=paths.end();++it ){
+		string normalized=normalizeUserLibDir( *it );
+		if( seen.insert( normalized ).second ) unique.push_back( *it );
+	}
+
+	return unique;
+}
+
 static const char *loadUserLib(const string& path, const string &userlib ){
 	
 	string t=path+userlib;
@@ -259,13 +284,9 @@ static const char *linkUserLibs(const char* cwd){
 
 	_ulibkws.clear();
 
-	const string roots[3]={
-		home + "/../userlibs/",
-		string(cwd) + "/userlibs/",
-		string(cwd) + "/../userlibs/",
-	};
-	for( int i=0;i<3;++i ){
-		if( const char *err=scanUserLibDir( roots[i] ) ){
+	const vector<string> paths=userLibSearchPaths( cwd );
+	for( vector<string>::const_iterator it=paths.begin();it!=paths.end();++it ){
+		if( const char *err=scanUserLibDir( *it ) ){
 			_ulibkws.clear();
 			return err;
 		}


### PR DESCRIPTION
## Non-technical summary
This fixes a compiler startup bug where BlitzForge could load the same `userlibs` declaration file twice when compiling from a nested working directory such as `tests/`.

That false double-load surfaced as a duplicate identifier error even though only one declaration file existed. After this change, equivalent search roots are de-duplicated before scanning, so the compiler only links each `userlibs` directory once.

## Technical summary
- normalize candidate `userlibs` search directories in `src/blitzrc/blitz/libs.cpp`
- de-duplicate resolved paths before scanning `*.decls` files
- replace the stateful multi-step search loop with a simpler per-directory iteration that preserves the existing search order
- keep declaration parsing and runtime DLL loading behavior unchanged
- no new automated tests were added because the current `develop` snapshot only exposes Windows batch-based compiler tests and this macOS environment does not have a runnable `blitzcc` binary for end-to-end execution

## Additional notes
- Trade-off: this change is intentionally limited to compiler-side declaration discovery; it does not alter runtime DLL lookup behavior
- Follow-up work intentionally deferred: adding a cross-platform or CI-backed regression harness for userlib discovery would make future path-search fixes easier to verify automatically
- Remaining gap: broader build and test automation for non-Windows environments is still absent on `develop`
