### PR TITLE
Protect blitzcc target-flag workflow coverage

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -1,12 +1,17 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 
 set ROOTDIR=%CD%
 
-cd %ROOTDIR%\tests
-
 set BLITZPATH=%ROOTDIR%
 set FAILED=0
+set SAMPLE=%ROOTDIR%\tests\NumberTest.bb
+
+call :expect_success "host alias compiles NumberTest" -c +q -target host "%SAMPLE%"
+call :expect_success "native Windows target compiles NumberTest" -c +q -target windows-x86 "%SAMPLE%"
+call :expect_failure "foreign macOS target is rejected" "Unsupported -target" -c +q -target macos-arm64 "%SAMPLE%"
+
+cd %ROOTDIR%\tests
 
 for /R %%f in (*.bb) do (
     "%BLITZPATH%\bin\blitzcc.exe" -t "%%f" || (echo "%%f failed at least one test" && SET FAILED=1)
@@ -15,7 +20,7 @@ for /R %%f in (*.bb) do (
 
 cd %ROOTDIR%
 
-if %FAILED% == 1 (
+if !FAILED! == 1 (
     echo "Tests failed"
     endlocal
     exit /b 1
@@ -24,3 +29,36 @@ if %FAILED% == 1 (
 echo "Tests passed"
 
 endlocal
+exit /b 0
+
+:expect_success
+set "LABEL=%~1"
+shift /1
+"%BLITZPATH%\bin\blitzcc.exe" %* >nul 2>&1
+if errorlevel 1 (
+    echo target contract FAILED: !LABEL!
+    set FAILED=1
+)
+exit /b 0
+
+:expect_failure
+set "LABEL=%~1"
+set "EXPECTED=%~2"
+shift /1
+shift /1
+set "TARGET_LOG=%TEMP%\blitzforge-target-%RANDOM%-%RANDOM%.log"
+"%BLITZPATH%\bin\blitzcc.exe" %* >"!TARGET_LOG!" 2>&1
+set "TARGET_RC=!ERRORLEVEL!"
+if !TARGET_RC! EQU 0 (
+    echo target contract FAILED: !LABEL! unexpectedly succeeded
+    set FAILED=1
+) else (
+    findstr /C:"!EXPECTED!" "!TARGET_LOG!" >nul
+    if errorlevel 1 (
+        echo target contract FAILED: !LABEL! did not report the unsupported-target error
+        type "!TARGET_LOG!"
+        set FAILED=1
+    )
+)
+del /q "!TARGET_LOG!" >nul 2>&1
+exit /b 0

--- a/test.bat
+++ b/test.bat
@@ -34,7 +34,7 @@ exit /b 0
 :expect_success
 set "LABEL=%~1"
 shift /1
-"%BLITZPATH%\bin\blitzcc.exe" %* >nul 2>&1
+"%BLITZPATH%\bin\blitzcc.exe" %1 %2 %3 %4 %5 %6 %7 %8 %9 >nul 2>&1
 if errorlevel 1 (
     echo target contract FAILED: !LABEL!
     set FAILED=1
@@ -47,7 +47,7 @@ set "EXPECTED=%~2"
 shift /1
 shift /1
 set "TARGET_LOG=%TEMP%\blitzforge-target-%RANDOM%-%RANDOM%.log"
-"%BLITZPATH%\bin\blitzcc.exe" %* >"!TARGET_LOG!" 2>&1
+"%BLITZPATH%\bin\blitzcc.exe" %1 %2 %3 %4 %5 %6 %7 %8 %9 >"!TARGET_LOG!" 2>&1
 set "TARGET_RC=!ERRORLEVEL!"
 if !TARGET_RC! EQU 0 (
     echo target contract FAILED: !LABEL! unexpectedly succeeded

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TESTDIR="${ROOTDIR}/tests"
+TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/blitzforge-tests.XXXXXX")"
+trap 'rm -rf "${TEST_TMPDIR}"' EXIT
 
 BLITZCC_UNIX="${ROOTDIR}/bin/blitzcc"
 BLITZCC_WIN="${ROOTDIR}/bin/blitzcc.exe"
@@ -24,6 +26,52 @@ else
 fi
 
 FAILED=0
+TARGET_SAMPLE="${TESTDIR}/NumberTest.bb"
+
+run_target_expect_success() {
+  local label="$1"
+  shift
+  if ! "${BLITZCC}" -c +q "$@" "${TARGET_SAMPLE}" \
+    > "${TEST_TMPDIR}/target-success.out" 2> "${TEST_TMPDIR}/target-success.err"; then
+    echo "target contract FAILED: ${label}" >&2
+    cat "${TEST_TMPDIR}/target-success.err" >&2
+    FAILED=1
+  fi
+}
+
+run_target_expect_failure() {
+  local label="$1"
+  shift
+  set +e
+  "${BLITZCC}" -c +q "$@" "${TARGET_SAMPLE}" \
+    > "${TEST_TMPDIR}/target-failure.out" 2> "${TEST_TMPDIR}/target-failure.err"
+  local rc=$?
+  set -e
+
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "target contract FAILED: ${label} unexpectedly succeeded" >&2
+    FAILED=1
+    return
+  fi
+
+  if ! grep -q "Unsupported -target" "${TEST_TMPDIR}/target-failure.out"; then
+    echo "target contract FAILED: ${label} did not report the unsupported-target error" >&2
+    echo "--- stdout ---" >&2
+    cat "${TEST_TMPDIR}/target-failure.out" >&2
+    echo "--- stderr ---" >&2
+    cat "${TEST_TMPDIR}/target-failure.err" >&2
+    FAILED=1
+  fi
+}
+
+run_target_expect_success "host alias compiles NumberTest" -target host
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  run_target_expect_success "native macOS target compiles NumberTest" -target macos-arm64
+  run_target_expect_failure "foreign Windows target is rejected" -target windows-x86
+else
+  run_target_expect_failure "foreign macOS target is rejected" -target macos-arm64
+fi
+
 while IFS= read -r -d '' f; do
   if ! "${BLITZCC}" "${TARGET_FLAG[@]}" "${EXEC_FLAG[@]}" -t "${f}"; then
     echo "\"${f}\" failed at least one test"
@@ -39,19 +87,17 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # the stub runtime is still in place. It does NOT silently succeed when
   # nothing actually ran.
   STUB_SENTINEL="BlitzForge stub runtime: native execution is not yet implemented"
-  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/blitzcc-arm64-exec.XXXXXX")"
-  trap 'rm -rf "${tmpdir}"' EXIT
-  cat > "${tmpdir}/arm64_exec_smoke.bb" <<'EOF'
+  cat > "${TEST_TMPDIR}/arm64_exec_smoke.bb" <<'EOF'
 Print "arm64_exec_smoke"
 End
 EOF
   set +e
-  "${BLITZCC}" +q -target macos-arm64 "${tmpdir}/arm64_exec_smoke.bb" \
-    > "${tmpdir}/arm64_exec_smoke.out" 2> "${tmpdir}/arm64_exec_smoke.err"
+  "${BLITZCC}" +q -target macos-arm64 "${TEST_TMPDIR}/arm64_exec_smoke.bb" \
+    > "${TEST_TMPDIR}/arm64_exec_smoke.out" 2> "${TEST_TMPDIR}/arm64_exec_smoke.err"
   smoke_rc=$?
   set -e
-  smoke_stdout="$(tr -d '\r' < "${tmpdir}/arm64_exec_smoke.out")"
-  smoke_stderr="$(cat "${tmpdir}/arm64_exec_smoke.err")"
+  smoke_stdout="$(tr -d '\r' < "${TEST_TMPDIR}/arm64_exec_smoke.out")"
+  smoke_stderr="$(cat "${TEST_TMPDIR}/arm64_exec_smoke.err")"
   if [[ "${smoke_stdout}" == "arm64_exec_smoke" && "${smoke_rc}" -eq 0 ]]; then
     echo "arm64 execution smoke: native runtime executed program correctly."
   elif grep -q "${STUB_SENTINEL}" <<<"${smoke_stderr}"; then


### PR DESCRIPTION
## Non-technical summary
This hardens the developer and CI workflows around `blitzcc` target selection. The repository now depends on the `-target` flag for documented local testing and recent macOS alpha work, so this change adds explicit checks that accepted targets still compile and unsupported targets still fail clearly.

Why this matters now: the `-target` parser was added only recently, after the documented workflow had already drifted into a broken state. Locking that contract into the test entrypoints makes the next regression show up immediately in the same scripts contributors and CI already run.

After this change, the system is better because target-selection regressions fail fast instead of silently breaking `test.sh`, `test.bat`, or the host-specific CI assumptions they encode.

## Technical summary
- Added explicit `-target` contract checks to `test.sh` before the existing suite runs.
- Verified the host alias still compiles on Unix hosts, the native macOS target still compiles on Darwin, and an unsupported foreign target is rejected with the expected error.
- Added matching Windows-side checks to `test.bat` for `host`, `windows-x86`, and rejected `macos-arm64` usage.
- Reused the existing test entrypoints instead of introducing a parallel harness, so the new coverage runs anywhere the repository already runs its test scripts.
- Preserved the existing macOS alpha runtime smoke behavior while consolidating temporary artifacts under one cleanup directory.
- Breaking changes: none.

## Additional notes
- Trade-off: this improves workflow-contract coverage without introducing a dedicated CLI unit-test harness; that keeps the scope small and aligned with current repo norms.
- Deferred follow-up: if the project later adds more real codegen targets, these script-level assertions should grow with that matrix or move into a more formal CLI test harness.
- Remaining gap: Windows-side execution of the new batch assertions was reviewed statically in this macOS environment, but not run live here because `cmd.exe` is unavailable on this host.