### PR TITLE
Make BlitzForge Git hooks portable across contributor environments

### DIFF
--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -1,28 +1,37 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Flag to track if changes are made
+MARKER=';~IDEal Editor Parameters:'
 CHANGES_MADE=0
 
-# Loop through all files in the last commit
-git diff-tree --no-commit-id --name-only -r HEAD | while IFS= read -r FILE; do
-    # Check if file extension is .bb, .bp, .brc, or .bmx
-    if echo "$FILE" | grep -qE "\.(bb|bp|brc|bmx|BB)$"; then
-        # Check if the file contains the specific line
-        if grep -q ';~IDEal Editor Parameters:' "$FILE"; then
-            # Get the line number of the first occurrence of the specific line
-            LINE_NUM=$(grep -n ';~IDEal Editor Parameters:' "$FILE" | cut -d: -f1 | head -n 1)
-            sed -i "${LINE_NUM},\$d" "$FILE"
-            # Remove the last newline character left over
-            head -c -1 "$FILE" > tmp
-            mv tmp "$FILE"
-            CHANGES_MADE=1
-        fi
+trim_ideal_metadata() {
+  local file="$1"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/blitzforge-post-commit.XXXXXX")"
+  awk -v marker="${MARKER}" '
+    index($0, marker) == 1 { exit }
+    {
+      if (count++) {
+        printf "\n"
+      }
+      printf "%s", $0
+    }
+  ' "${file}" > "${tmp}"
+  mv "${tmp}" "${file}"
+}
 
-        
-    fi
-done
+while IFS= read -r file; do
+  [[ -f "${file}" ]] || continue
+  case "${file##*.}" in
+    bb|BB|bp|BP|brc|BRC|bmx|BMX)
+      if grep -qF "${MARKER}" "${file}"; then
+        trim_ideal_metadata "${file}"
+        CHANGES_MADE=1
+      fi
+      ;;
+  esac
+done < <(git diff-tree --root --no-commit-id --name-only -r HEAD)
 
-# If changes were made, inform the user
-if [ "$CHANGES_MADE" -eq 1 ]; then
-    echo "Post-commit hook made changes to files. Please review and commit them."
+if [[ "${CHANGES_MADE}" -eq 1 ]]; then
+  echo "Post-commit hook removed IDEal editor metadata. Review and commit the cleaned files."
 fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,16 +1,17 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Run the batch script
-cmd.exe /C test.bat
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HOOK_DIR}/.." && pwd)"
 
-# Capture the exit code of the batch script
-exit_code=$?
-
-# Optionally, do something based on the exit code
-if [ $exit_code -ne 0 ]; then
-    echo "The pre-commit script exited with error code $exit_code"
-    # Exit the shell script with the same code
-    exit $exit_code
-else
-    echo "The pre-commit script completed successfully."
-fi
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    (
+      cd "${REPO_ROOT}"
+      cmd.exe /C test.bat
+    )
+    ;;
+  *)
+    "${REPO_ROOT}/test.sh"
+    ;;
+esac

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -178,7 +178,14 @@ Every push and every pull request runs:
 - **Build + test** ([`ci.yml`](.github/workflows/ci.yml)) — compiles `blitzcc` and runs the Blitz test suite.
 - **Workflow lint** ([`static-analysis.yml`](.github/workflows/static-analysis.yml)) — `yamllint` and `actionlint` for GitHub Actions hygiene.
 
-The full test suite also runs as a local pre-commit hook. **Tests must pass to commit.**
+This repo ships local Git hooks under [`.hooks/`](.hooks), but they are opt-in per clone. Enable them once with `git config core.hooksPath .hooks`.
+
+After that:
+
+- the `pre-commit` hook runs `test.bat` on Windows shells and `test.sh` on Unix-like hosts,
+- the `post-commit` hook strips `;~IDEal Editor Parameters:` metadata from committed Blitz source files so IDE-only noise does not linger in the tree.
+
+**Tests must pass to commit.**
 
 ## Documentation
 
@@ -200,10 +207,11 @@ The full test suite also runs as a local pre-commit hook. **Tests must pass to c
 ### Workflow
 
 1. Fork or clone; branch from `develop`.
-2. Add or update tests in [`tests/`](tests) for any behavior change.
-3. Run `compile.bat` / `compile.sh` and `test.bat` / `test.sh` locally.
-4. Open a PR targeting `develop`. Releases are PRs from `develop` → `master`.
-5. CI must be green.
+2. Enable the repo hooks once per clone: `git config core.hooksPath .hooks`.
+3. Add or update tests in [`tests/`](tests) for any behavior change.
+4. Run `compile.bat` / `compile.sh` and `test.bat` / `test.sh` locally.
+5. Open a PR targeting `develop`. Releases are PRs from `develop` → `master`.
+6. CI must be green.
 
 For push access, request to join the [**RCCE Contributors team**](https://github.com/orgs/RydeTec/teams/rcce-contributors).
 


### PR DESCRIPTION
## Non-technical summary
This makes BlitzForge's shipped local Git hooks usable across contributor environments instead of only on Windows shells. Contributors can now opt into the repo hooks with one Git config command, and the README explains what those hooks actually do.

Why this matters now: the live `develop` docs said the full test suite ran as a local pre-commit hook, but on macOS the hook immediately failed because it hard-called `cmd.exe`, and the post-commit cleanup logic depended on GNU-only shell behavior. That made the contributor workflow claim stronger than the implementation.

After this change, the system is better because the documented local hook workflow is honest, cross-platform, and reproducible for fresh clones.

## Technical summary
- Reworked `.hooks/pre-commit` to resolve the repo root and dispatch to `test.bat` on Windows shells or `test.sh` on Unix-like hosts.
- Reworked `.hooks/post-commit` to use portable Bash + `awk` cleanup instead of GNU-specific `sed -i` and `head -c -1` behavior.
- Made the post-commit cleanup handle root commits and skip deleted files safely.
- Updated `ReadMe.md` to document `git config core.hooksPath .hooks`, explain the shipped hook behavior, and stop implying hooks are automatic.
- Breaking changes: none.

## Additional notes
- Trade-off: this keeps the existing hook model instead of introducing a dedicated hook installer script, which keeps the increment small and aligned with the current repo structure.
- Deferred follow-up: if the project wants hooks enabled automatically for all contributors, a bootstrap/setup command would be the next step.
- Remaining gap: the Windows batch path was validated by dispatch logic and existing script compatibility, but not executed live in this macOS environment.
