### PR TITLE
Make Windows batch entrypoints location-relative

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,14 +1,14 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-set ROOTDIR=%CD%
+for %%I in ("%~dp0.") do set "ROOTDIR=%%~fI"
 
 echo Compiling BlitzForge Toolchain...
-call .\scripts\msbuild_init.bat
+call "%ROOTDIR%\scripts\msbuild_init.bat"
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
-call .\scripts\msbuild_blitzforge.bat
+call "%ROOTDIR%\scripts\msbuild_blitzforge.bat"
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 endlocal

--- a/publish.bat
+++ b/publish.bat
@@ -1,11 +1,11 @@
 @echo off
 setlocal
 
-set ROOTDIR=%CD%
+for %%I in ("%~dp0.") do set "ROOTDIR=%%~fI"
 
-call .\compile.bat
+call "%ROOTDIR%\compile.bat"
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
 if exist "%ROOTDIR%\release" rmdir /S /Q "%ROOTDIR%\release"
 
@@ -25,7 +25,7 @@ REM Copy the compiled vscode extension
 if exist "%ROOTDIR%\..\..\extras\vscode-blitz-forge" (
     call "%ROOTDIR%\..\..\extras\vscode-blitz-forge\compile.bat"
 
-    cd %ROOTDIR%
+    cd /d "%ROOTDIR%"
     
     xcopy /Y "%ROOTDIR%\..\..\extras\vscode-blitz-forge\*.vsix" "%ROOTDIR%\release\"
 )

--- a/test.bat
+++ b/test.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-set ROOTDIR=%CD%
+for %%I in ("%~dp0.") do set "ROOTDIR=%%~fI"
 
 set BLITZPATH=%ROOTDIR%
 set FAILED=0
@@ -11,14 +11,14 @@ call :expect_success "host alias compiles NumberTest" -c +q -target host "%SAMPL
 call :expect_success "native Windows target compiles NumberTest" -c +q -target windows-x86 "%SAMPLE%"
 call :expect_failure "foreign macOS target is rejected" "Unsupported -target" -c +q -target macos-arm64 "%SAMPLE%"
 
-cd %ROOTDIR%\tests
+cd /d "%ROOTDIR%\tests"
 
 for /R %%f in (*.bb) do (
     "%BLITZPATH%\bin\blitzcc.exe" -t "%%f" || (echo "%%f failed at least one test" && SET FAILED=1)
     echo.
 )
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
 if !FAILED! == 1 (
     echo "Tests failed"


### PR DESCRIPTION
## Non-technical summary
This fixes the Windows command entrypoints so the build, test, and publish scripts work when they are launched from outside the repository root.

This matters now because the repo has already moved its hooks and Unix scripts toward location-relative behavior, but the main Windows batch entrypoints still depended on the caller's current directory. That made routine contributor workflows fragile for no product benefit.

After this change, the Windows batch workflow is more predictable: `compile.bat`, `test.bat`, and `publish.bat` now anchor themselves to the repo checkout instead of the shell location they were launched from.

## Technical summary
- Updated `compile.bat` to derive `ROOTDIR` from `%~dp0`, switch drives with `cd /d`, and call the `scripts/` helpers via absolute repo-root paths.
- Updated `test.bat` to derive `ROOTDIR` from `%~dp0` and use `cd /d` for the test loop and repo-root return path.
- Updated `publish.bat` to call `compile.bat` through an absolute repo-root path and use `cd /d` when returning to the checkout root.
- Verified the live tree with `./test.sh` on macOS after the change; the existing macOS compile-only test flow still passes.
- Windows `cmd.exe` execution was not available on this host, so Windows proof for the batch behavior is static review of the changed control flow rather than local runtime execution.
- No breaking API or product-surface changes.

## Additional notes
Trade-off: I kept the scope strictly to path resolution and drive-safe directory changes instead of broadening into batch-script cleanup.

Deferred follow-up: the helper batch scripts under `scripts/` could be given the same caller-independent treatment in a separate pass if we want every Windows helper to follow the same contract.

Remaining gap: this closes the top-level entrypoint fragility, but hosted or native Windows execution is still the stronger proof surface for the batch behavior itself.