### PR TITLE
Make publish scripts emit release ZIP archives

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -138,10 +138,10 @@ cd blitz-forge
 ./scripts/bootstrap_macos.sh    # one-time: installs cmake/ninja/llvm and runtime deps via Homebrew
 ./compile.sh                    # builds bin/blitzcc, bin/runtime.dylib, bin/linker.dylib
 ./test.sh                       # runs tests/*.bb against -target macos-arm64
-./publish.sh                    # produce a redistributable archive
+./publish.sh                    # stage release/ and write release/blitzforge-macos-arm64.zip
 ```
 
-Build artifacts land in [`bin/`](bin) and a redistributable archive in `release/`.
+Build artifacts land in [`bin/`](bin), a staged [`release/`](release) directory, and a redistributable ZIP archive such as `release/blitzforge-macos-arm64.zip` or `release/blitzforge-windows-x64.zip`.
 
 The compiler accepts an explicit `-target` flag (`host`, `windows-x86`, or `macos-arm64`). On macOS hosts, `host` and `macos-arm64` are equivalent; cross-compiling to a foreign target is rejected up-front rather than producing a broken artifact. Until a native macOS runtime is wired up, `./test.sh` validates the full compile/translate/assemble pipeline and explicitly **skips** the in-process execution smoke with a clear "alpha stub runtime" notice — so a stub runtime can never be silently mistaken for a working one.
 

--- a/publish.bat
+++ b/publish.bat
@@ -2,6 +2,8 @@
 setlocal
 
 for %%I in ("%~dp0.") do set "ROOTDIR=%%~fI"
+set "ARCHIVE_BASENAME=blitzforge-windows-x64"
+set "ARCHIVE_PATH=%ROOTDIR%\release\%ARCHIVE_BASENAME%.zip"
 
 call "%ROOTDIR%\compile.bat"
 
@@ -32,5 +34,19 @@ if exist "%ROOTDIR%\..\..\extras\vscode-blitz-forge" (
 
 REM Create a README.txt file
 echo "BlitzForge is a compiler for an enhanced version of the Blitz3D language. It is a fork of the Blitz3D compiler and adds support for the BlitzForge commands and syntax. You can develop with BlitzForge in Visual Studio Code by installing the .vsix extension. Press Ctrl+Shift+P and search for vsix to install the extension." > "%ROOTDIR%\release\README.txt"
+
+set "PACKAGE_TMP=%TEMP%\blitzforge-package-%RANDOM%-%RANDOM%"
+set "PACKAGE_ROOT=%PACKAGE_TMP%\%ARCHIVE_BASENAME%"
+mkdir "%PACKAGE_ROOT%"
+xcopy /E /Y /I "%ROOTDIR%\release\*" "%PACKAGE_ROOT%\" >nul
+if exist "%ARCHIVE_PATH%" del /Q "%ARCHIVE_PATH%"
+powershell -NoProfile -Command "Compress-Archive -Path '%PACKAGE_ROOT%' -DestinationPath '%ARCHIVE_PATH%' -CompressionLevel Optimal"
+if errorlevel 1 (
+    rd /S /Q "%PACKAGE_TMP%"
+    endlocal
+    exit /b 1
+)
+rd /S /Q "%PACKAGE_TMP%"
+echo Created release archive: "%ARCHIVE_PATH%"
 
 endlocal

--- a/publish.sh
+++ b/publish.sh
@@ -4,6 +4,39 @@ set -euo pipefail
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELEASE_DIR="${ROOTDIR}/release"
 
+host_archive_basename() {
+  case "$(uname -s)" in
+    Darwin) echo "blitzforge-macos-arm64" ;;
+    Linux) echo "blitzforge-linux-host" ;;
+    *) echo "blitzforge-unix-host" ;;
+  esac
+}
+
+create_zip_archive() {
+  local source_parent="$1"
+  local source_name="$2"
+  local archive_path="$3"
+
+  if command -v zip >/dev/null 2>&1; then
+    (
+      cd "${source_parent}"
+      zip -qr "${archive_path}" "${source_name}"
+    )
+    return
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    (
+      cd "${source_parent}"
+      python3 -m zipfile -c "${archive_path}" "${source_name}"
+    )
+    return
+  fi
+
+  echo "Unable to create release archive: install zip or python3." >&2
+  exit 1
+}
+
 "${ROOTDIR}/compile.sh"
 
 rm -rf "${RELEASE_DIR}"
@@ -25,3 +58,15 @@ BlitzForge is a compiler for an enhanced version of the Blitz3D language.
 It is a fork of the Blitz3D compiler and adds support for BlitzForge commands and syntax.
 You can develop with BlitzForge in Visual Studio Code by installing the bundled .vsix extension.
 EOF
+
+ARCHIVE_BASENAME="$(host_archive_basename)"
+ARCHIVE_PATH="${RELEASE_DIR}/${ARCHIVE_BASENAME}.zip"
+PACKAGE_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/blitzforge-package.XXXXXX")"
+trap 'rm -rf "${PACKAGE_TMPDIR}"' EXIT
+PACKAGE_ROOT="${PACKAGE_TMPDIR}/${ARCHIVE_BASENAME}"
+mkdir -p "${PACKAGE_ROOT}"
+rsync -a "${RELEASE_DIR}/" "${PACKAGE_ROOT}/"
+rm -f "${ARCHIVE_PATH}"
+create_zip_archive "${PACKAGE_TMPDIR}" "${ARCHIVE_BASENAME}" "${ARCHIVE_PATH}"
+
+echo "Created release archive: ${ARCHIVE_PATH}"


### PR DESCRIPTION
## Non-technical summary
- `publish.sh` and `publish.bat` now produce the release ZIP archives the repo already advertises, instead of stopping at a staged `release/` directory.
- This matters now because the README and release install surface already promise downloadable ZIP artifacts, so contributors should get that result directly from the publish entrypoints.
- After this change, release packaging is less ambiguous: the staged tree still exists for inspection, and the host-specific ZIP is created alongside it in `release/`.

## Technical summary
- Added host-aware archive creation to [`publish.sh`](https://github.com/RydeTec/blitz-forge/blob/align/publish-release-archives/publish.sh) so Unix publish runs now emit `release/blitzforge-macos-arm64.zip` on macOS and preserve a consistent top-level folder inside the archive.
- Added matching archive creation to [`publish.bat`](https://github.com/RydeTec/blitz-forge/blob/align/publish-release-archives/publish.bat) using PowerShell `Compress-Archive`, keeping the existing staged `release/` tree intact.
- Updated [`ReadMe.md`](https://github.com/RydeTec/blitz-forge/blob/align/publish-release-archives/ReadMe.md) so the documented publish output matches the actual staged directory plus ZIP artifact behavior.
- Verification:
  - `bash -n publish.sh`
  - `git diff --check`
  - simulated `./publish.sh` packaging run against the existing built `bin/` artifacts with a temporary `cmake` stub because this host does not currently have `cmake` / Homebrew installed
  - inspected `release/blitzforge-macos-arm64.zip` with `unzip -l` to confirm the expected top-level archive folder and packaged contents
- Breaking changes: none.

## Additional notes
- Trade-off: I kept the existing `release/` staging directory instead of replacing it, so any local workflows that inspect unpacked release contents keep working.
- Deferred follow-up: there is still no versioned or tag-driven release publishing flow here; this increment only makes the existing publish entrypoints honest and complete.
- Remaining gap to the fuller release vision: GitHub Releases publication and artifact naming/version stamping are still manual.