### PR TITLE
Harden Windows release packaging

### DIFF
--- a/publish.bat
+++ b/publish.bat
@@ -6,6 +6,7 @@ set "ARCHIVE_BASENAME=blitzforge-windows-x64"
 set "ARCHIVE_PATH=%ROOTDIR%\release\%ARCHIVE_BASENAME%.zip"
 
 call "%ROOTDIR%\compile.bat"
+if errorlevel 1 goto :fail
 
 cd /d "%ROOTDIR%"
 
@@ -13,40 +14,73 @@ if exist "%ROOTDIR%\release" rmdir /S /Q "%ROOTDIR%\release"
 
 mkdir "%ROOTDIR%\release"
 
-xcopy /E /Y /I "%ROOTDIR%\bin" "%ROOTDIR%\release\bin"
-xcopy /E /Y /I "%ROOTDIR%\cfg" "%ROOTDIR%\release\cfg"
-xcopy /E /Y /I "%ROOTDIR%\games" "%ROOTDIR%\release\games"
-xcopy /E /Y /I "%ROOTDIR%\help" "%ROOTDIR%\release\help"
-xcopy /E /Y /I "%ROOTDIR%\media" "%ROOTDIR%\release\media"
-xcopy /E /Y /I "%ROOTDIR%\mediaview" "%ROOTDIR%\release\mediaview"
-xcopy /E /Y /I "%ROOTDIR%\samples" "%ROOTDIR%\release\samples"
-xcopy /E /Y /I "%ROOTDIR%\tutorials" "%ROOTDIR%\release\tutorials"
-xcopy /E /Y /I "%ROOTDIR%\userlibs" "%ROOTDIR%\release\userlibs"
+call :copy_tree_if_exists "%ROOTDIR%\bin" "%ROOTDIR%\release\bin"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\cfg" "%ROOTDIR%\release\cfg"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\games" "%ROOTDIR%\release\games"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\help" "%ROOTDIR%\release\help"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\media" "%ROOTDIR%\release\media"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\mediaview" "%ROOTDIR%\release\mediaview"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\samples" "%ROOTDIR%\release\samples"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\tutorials" "%ROOTDIR%\release\tutorials"
+if errorlevel 1 goto :fail
+call :copy_tree_if_exists "%ROOTDIR%\userlibs" "%ROOTDIR%\release\userlibs"
+if errorlevel 1 goto :fail
 
 REM Copy the compiled vscode extension
 if exist "%ROOTDIR%\..\..\extras\vscode-blitz-forge" (
     call "%ROOTDIR%\..\..\extras\vscode-blitz-forge\compile.bat"
+    if errorlevel 1 goto :fail
 
     cd /d "%ROOTDIR%"
     
-    xcopy /Y "%ROOTDIR%\..\..\extras\vscode-blitz-forge\*.vsix" "%ROOTDIR%\release\"
+    if exist "%ROOTDIR%\..\..\extras\vscode-blitz-forge\*.vsix" (
+        xcopy /Y "%ROOTDIR%\..\..\extras\vscode-blitz-forge\*.vsix" "%ROOTDIR%\release\" >nul
+        if errorlevel 1 goto :fail
+    )
 )
 
 REM Create a README.txt file
-echo "BlitzForge is a compiler for an enhanced version of the Blitz3D language. It is a fork of the Blitz3D compiler and adds support for the BlitzForge commands and syntax. You can develop with BlitzForge in Visual Studio Code by installing the .vsix extension. Press Ctrl+Shift+P and search for vsix to install the extension." > "%ROOTDIR%\release\README.txt"
+(
+    echo BlitzForge is a compiler for an enhanced version of the Blitz3D language.
+    echo It is a fork of the Blitz3D compiler and adds support for BlitzForge commands and syntax.
+    echo You can develop with BlitzForge in Visual Studio Code by installing the bundled .vsix extension.
+) > "%ROOTDIR%\release\README.txt"
 
 set "PACKAGE_TMP=%TEMP%\blitzforge-package-%RANDOM%-%RANDOM%"
 set "PACKAGE_ROOT=%PACKAGE_TMP%\%ARCHIVE_BASENAME%"
 mkdir "%PACKAGE_ROOT%"
 xcopy /E /Y /I "%ROOTDIR%\release\*" "%PACKAGE_ROOT%\" >nul
+if errorlevel 1 goto :fail
 if exist "%ARCHIVE_PATH%" del /Q "%ARCHIVE_PATH%"
 powershell -NoProfile -Command "Compress-Archive -Path '%PACKAGE_ROOT%' -DestinationPath '%ARCHIVE_PATH%' -CompressionLevel Optimal"
 if errorlevel 1 (
-    rd /S /Q "%PACKAGE_TMP%"
-    endlocal
-    exit /b 1
+    goto :fail
 )
 rd /S /Q "%PACKAGE_TMP%"
 echo Created release archive: "%ARCHIVE_PATH%"
 
 endlocal
+exit /b 0
+
+:copy_tree_if_exists
+set "COPY_SOURCE=%~1"
+set "COPY_DEST=%~2"
+if not exist "%COPY_SOURCE%\" exit /b 0
+xcopy /E /Y /I "%COPY_SOURCE%" "%COPY_DEST%" >nul
+if errorlevel 1 (
+    echo Failed to copy "%COPY_SOURCE%" into "%COPY_DEST%"
+    exit /b 1
+)
+exit /b 0
+
+:fail
+if exist "%PACKAGE_TMP%" rd /S /Q "%PACKAGE_TMP%"
+endlocal
+exit /b 1


### PR DESCRIPTION
## Non-technical summary
This hardens the Windows release packaging path so `publish.bat` stops on real packaging failures and no longer tries to copy optional artifacts that are not present. That matters now because the repo’s Windows publisher should be as trustworthy as the Unix publisher when maintainers cut release archives.

## Technical summary
- make `publish.bat` fail fast if `compile.bat` fails instead of continuing into archive staging
- add a `:copy_tree_if_exists` helper so release packaging only copies directories that are actually present
- guard the optional VS Code extension copy so an existing extras checkout without a built `.vsix` is treated as optional instead of producing a noisy wildcard copy failure
- check archive staging copy failures before invoking `Compress-Archive`
- rewrite the generated `release\\README.txt` content without literal quote characters and align the wording with the Unix publisher more closely

## Additional notes
Trade-offs: validation on this macOS host is static only for the batch script because `cmd.exe` is not available here.

Follow-up intentionally deferred: there is still no repo-local automated Windows batch regression harness; hosted Windows CI remains the stronger proof path for runtime execution of `publish.bat`.

Breaking changes: none.