### PR TITLE
Fail fast on unrunnable Unix host builds

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -4,59 +4,95 @@ set -euo pipefail
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_RUNTIME=0
 
+host_system() {
+  if [[ -n "${BLITZFORGE_BUILD_HOST_SYSTEM:-}" ]]; then
+    printf '%s\n' "${BLITZFORGE_BUILD_HOST_SYSTEM}"
+    return
+  fi
+
+  uname -s
+}
+
+require_supported_build_host() {
+  local system_name="${1:-$(host_system)}"
+
+  case "${system_name}" in
+    Darwin|MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    Linux)
+      echo "compile.sh currently supports runnable host builds only on macOS." >&2
+      echo "Linux builds still lack the companion runtime/linker shared libraries blitzcc loads at startup." >&2
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
 usage() {
   cat <<'EOF'
 BlitzForge Compiler Script
 
 -r | --with-runtime   Build runtime/linker shared libraries for host-target macOS support
 -h | --help           Show this help
+
+Note: runnable Unix host builds are currently supported only on macOS.
 EOF
 }
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -r|--with-runtime) BUILD_RUNTIME=1 ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "Unknown flag: $1" >&2; usage; exit 1 ;;
-  esac
-  shift
-done
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -r|--with-runtime) BUILD_RUNTIME=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "Unknown flag: $1" >&2; usage; exit 1 ;;
+    esac
+    shift
+  done
 
-if [[ "$(uname -s)" == "Darwin" && "${BUILD_RUNTIME}" -eq 0 ]]; then
-  # macOS host builds need the companion runtime/linker libraries for compiler loading.
-  BUILD_RUNTIME=1
-fi
+  HOST_SYSTEM="$(host_system)"
 
-if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
-  if ! command -v cmake >/dev/null 2>&1; then
-    if [[ "$(uname -s)" == "Darwin" && -x "${ROOTDIR}/scripts/bootstrap_macos.sh" ]]; then
-      echo "cmake not found, running macOS dependency bootstrap..."
-      "${ROOTDIR}/scripts/bootstrap_macos.sh"
-    else
-      echo "cmake is required. Install cmake (and optionally ninja), then re-run." >&2
+  if [[ "${HOST_SYSTEM}" == "Darwin" && "${BUILD_RUNTIME}" -eq 0 ]]; then
+    # macOS host builds need the companion runtime/linker libraries for compiler loading.
+    BUILD_RUNTIME=1
+  fi
+
+  if [[ "${HOST_SYSTEM}" == "Darwin" || "${HOST_SYSTEM}" == "Linux" ]]; then
+    require_supported_build_host "${HOST_SYSTEM}"
+
+    if ! command -v cmake >/dev/null 2>&1; then
+      if [[ "${HOST_SYSTEM}" == "Darwin" && -x "${ROOTDIR}/scripts/bootstrap_macos.sh" ]]; then
+        echo "cmake not found, running macOS dependency bootstrap..."
+        "${ROOTDIR}/scripts/bootstrap_macos.sh"
+      else
+        echo "cmake is required. Install cmake (and optionally ninja), then re-run." >&2
+        exit 1
+      fi
+    fi
+    if ! command -v cmake >/dev/null 2>&1; then
+      echo "cmake is still unavailable after bootstrap." >&2
       exit 1
     fi
-  fi
-  if ! command -v cmake >/dev/null 2>&1; then
-    echo "cmake is still unavailable after bootstrap." >&2
-    exit 1
-  fi
-  BUILD_DIR="${ROOTDIR}/build/host"
-  CMAKE_ARGS=(-S "${ROOTDIR}" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release)
-  if [[ "${BUILD_RUNTIME}" -eq 1 ]]; then
-    CMAKE_ARGS+=(-DBLITZFORGE_BUILD_RUNTIME=ON)
+    BUILD_DIR="${ROOTDIR}/build/host"
+    CMAKE_ARGS=(-S "${ROOTDIR}" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release)
+    if [[ "${BUILD_RUNTIME}" -eq 1 ]]; then
+      CMAKE_ARGS+=(-DBLITZFORGE_BUILD_RUNTIME=ON)
+    else
+      CMAKE_ARGS+=(-DBLITZFORGE_BUILD_RUNTIME=OFF)
+    fi
+    if command -v ninja >/dev/null 2>&1; then
+      CMAKE_ARGS+=(-G Ninja)
+    fi
+    cmake "${CMAKE_ARGS[@]}"
+    TARGETS=(blitzcc)
+    if [[ "${HOST_SYSTEM}" == "Darwin" && "${BUILD_RUNTIME}" -eq 1 ]]; then
+      TARGETS+=(runtime linker)
+    fi
+    cmake --build "${BUILD_DIR}" --target "${TARGETS[@]}" --parallel
   else
-    CMAKE_ARGS+=(-DBLITZFORGE_BUILD_RUNTIME=OFF)
+    "${ROOTDIR}/compile.bat"
   fi
-  if command -v ninja >/dev/null 2>&1; then
-    CMAKE_ARGS+=(-G Ninja)
-  fi
-  cmake "${CMAKE_ARGS[@]}"
-  TARGETS=(blitzcc)
-  if [[ "$(uname -s)" == "Darwin" && "${BUILD_RUNTIME}" -eq 1 ]]; then
-    TARGETS+=(runtime linker)
-  fi
-  cmake --build "${BUILD_DIR}" --target "${TARGETS[@]}" --parallel
-else
-  "${ROOTDIR}/compile.bat"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/scripts/test_compile_contract.sh
+++ b/scripts/test_compile_contract.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${ROOTDIR}/compile.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    fail "${label}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+assert_success() {
+  local label="$1"
+  shift
+  if ! "$@"; then
+    fail "${label}: command failed"
+  fi
+}
+
+assert_failure_with_stderr() {
+  local expected="$1"
+  shift
+  local stderr_file
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/compile-contract.XXXXXX")"
+  if "$@" > /dev/null 2> "${stderr_file}"; then
+    rm -f "${stderr_file}"
+    fail "expected failure but command succeeded"
+  fi
+  if ! grep -Fq "${expected}" "${stderr_file}"; then
+    cat "${stderr_file}" >&2
+    rm -f "${stderr_file}"
+    fail "stderr did not contain '${expected}'"
+  fi
+  rm -f "${stderr_file}"
+}
+
+BLITZFORGE_BUILD_HOST_SYSTEM=Darwin
+assert_eq "Darwin" "$(host_system)" "Darwin override"
+assert_success "Darwin host is allowed" require_supported_build_host
+
+BLITZFORGE_BUILD_HOST_SYSTEM=Linux
+assert_eq "Linux" "$(host_system)" "Linux override"
+assert_failure_with_stderr "runnable host builds only on macOS" require_supported_build_host
+
+echo "compile.sh contract tests passed"

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,20 @@ else
 fi
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
+  RUNTIME_LIB="${ROOTDIR}/bin/runtime.dylib"
+  LINKER_LIB="${ROOTDIR}/bin/linker.dylib"
+else
+  RUNTIME_LIB="${ROOTDIR}/bin/runtime.so"
+  LINKER_LIB="${ROOTDIR}/bin/linker.so"
+fi
+
+if [[ ! -f "${RUNTIME_LIB}" || ! -f "${LINKER_LIB}" ]]; then
+  echo "runtime/linker companion libraries are missing for this host build." >&2
+  echo "compile.sh only produces a runnable Unix blitzcc on macOS today." >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
   TARGET_FLAG=(-target macos-arm64)
   EXEC_FLAG=(-c)
 else


### PR DESCRIPTION
## Non-technical summary
- Stops the Unix helper scripts from pretending Linux can produce a runnable local BlitzForge toolchain today.
- Fails early with a clear explanation instead of leaving contributors with a `blitzcc` binary that cannot start because its companion libraries were never built.
- Keeps the existing macOS alpha workflow intact while making the unsupported Linux path explicit.

## Technical summary
- refactor `compile.sh` into sourceable helpers plus a `main()` guard so script-level contract tests can exercise host detection without accidentally launching a build
- add a Linux host guard in `compile.sh` that rejects unrunnable Unix builds before the CMake step
- add a `test.sh` preflight check for the required runtime/linker companion libraries so missing host artifacts fail with an explicit message
- add `scripts/test_compile_contract.sh` to lock the supported-host contract with Darwin success and Linux failure cases
- breaking changes: `./compile.sh` now exits early on Linux instead of producing a `bin/blitzcc` that cannot load `runtime`/`linker` at startup

## Additional notes
- Trade-off: this chooses honest failure over preserving a misleading partial build artifact.
- Intentionally deferred: shared README/CI wording updates are left for the already-open packaging PRs that touch those same surfaces, to avoid overlapping work in this run.
- Remaining gap: runnable Unix host builds still exist only on macOS until Linux runtime/linker support is implemented.