### PR TITLE
Clarify the repo licensing sources in public docs

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,0 +1,41 @@
+# Licensing Map
+
+BlitzForge does not currently publish a single repo-root project license file.
+Instead, the checked-in licensing terms live with the components they cover.
+
+This document is a pointer map to those authoritative notices. It is not a
+replacement for the original license texts.
+
+## Core compiler/runtime source
+
+- [`src/blitzrc/LICENSE.TXT`](src/blitzrc/LICENSE.TXT)
+  - Covers the inherited Blitz3D source release under `src/blitzrc/`.
+  - States that Blitz3D is released under the `zlib/libpng` license.
+
+## Bundled third-party libraries
+
+- [`src/libogg/COPYING`](src/libogg/COPYING)
+  - Redistribution terms for the bundled libogg sources from Xiph.org.
+
+- [`src/libvorbis/COPYING`](src/libvorbis/COPYING)
+  - Redistribution terms for the bundled libvorbis sources from Xiph.org.
+
+- [`src/freeimage241/license-fi.txt`](src/freeimage241/license-fi.txt)
+  - FreeImage Public License text shipped with the bundled FreeImage sources.
+
+- [`src/freeimage241/license-gpl.txt`](src/freeimage241/license-gpl.txt)
+  - GPL alternative text shipped alongside the bundled FreeImage sources.
+
+- [`src/freeimage241/Source/LibMNG/LICENSE`](src/freeimage241/Source/LibMNG/LICENSE)
+  - License notice for the bundled LibMNG sources that ship inside FreeImage.
+
+- [`src/freeimage241/Source/LibPNG/LICENSE`](src/freeimage241/Source/LibPNG/LICENSE)
+  - License notice for the bundled LibPNG sources that ship inside FreeImage.
+
+## Release artifact review
+
+The release packaging scripts copy compiled binaries plus bundled assets from
+directories such as `bin/`, `cfg/`, `games/`, `help/`, `media/`, `samples/`,
+`tutorials/`, and `userlibs/`. If you plan to redistribute a release archive,
+review the license notice(s) for every bundled component you ship, not just the
+compiler core.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,7 +6,7 @@
 
 ### Blitz3D, modernized.
 
-**An open-source, cross-platform compiler and runtime for the Blitz programming language** — keeping a generation of games and tools alive while moving them onto modern hardware.
+**A community-developed, cross-platform compiler and runtime for the Blitz programming language** — keeping a generation of games and tools alive while moving them onto modern hardware.
 
 ---
 
@@ -41,7 +41,7 @@
 
 Blitz3D and BlitzBasic shaped a generation of indie game development. The original toolchain was tied to 32-bit Windows, closed-source, and frozen. BlitzForge is the alternative:
 
-- **Open source.** MIT-style community development, public CI, no surprise binaries.
+- **Public source + public CI.** The compiler core and bundled third-party libraries carry checked-in license notices; see [LICENSES.md](LICENSES.md) for the source-of-truth paths.
 - **Cross-platform foundations.** Native Windows x86_64 is the stable target today. A macOS Apple Silicon (arm64) port is in **alpha** — same source tree, ARM64 codegen, Cocoa runtime backend — but not yet ready to ship games on. See [macOS (Apple Silicon) — alpha](#macos-apple-silicon--alpha) below.
 - **Modern build system.** CMake + Ninja, optional static analysis, GitHub Actions CI on every push.
 - **Drop-in compatible.** Existing `.bb` source compiles. Existing `.decls` userlibs work. We do not break your games.
@@ -239,7 +239,13 @@ BlitzForge is a respectful continuation of the work of Mark Sibly and the origin
 
 ## License
 
-BlitzForge is community-developed and openly available. Subsystems vendored from third parties retain their original licenses (see in-tree headers and `LICENSE` files where present). For questions about reuse, redistribution, or commercial use, please open a [Discussion](https://github.com/RydeTec/blitz-forge/discussions) or contact the maintainers.
+BlitzForge's licensing is currently documented through component-specific notices in the tree rather than a single repo-root `LICENSE` file.
+
+- The inherited compiler/runtime core under [`src/blitzrc/`](src/blitzrc) carries the original Blitz3D source release notice in [`src/blitzrc/LICENSE.TXT`](src/blitzrc/LICENSE.TXT), which states the `zlib/libpng` license.
+- Vendored third-party components retain their own bundled license texts, including [`src/libogg/COPYING`](src/libogg/COPYING), [`src/libvorbis/COPYING`](src/libvorbis/COPYING), [`src/freeimage241/license-fi.txt`](src/freeimage241/license-fi.txt), [`src/freeimage241/license-gpl.txt`](src/freeimage241/license-gpl.txt), and the nested notices under [`src/freeimage241/Source/`](src/freeimage241/Source/).
+- For a pointer map of the license files that matter to source checkouts and release artifacts, see [`LICENSES.md`](LICENSES.md).
+
+If you are evaluating reuse or redistribution, review the component notice(s) that cover the parts you intend to ship.
 
 ---
 


### PR DESCRIPTION
## Non-technical summary
- Clarifies where BlitzForge's real licensing terms live in the repository instead of implying a repo-wide MIT-style grant.
- Gives contributors and redistributors one place to find the checked-in notice files that actually govern the compiler core and bundled third-party libraries.
- Reduces the chance of someone making reuse or packaging decisions from an overstated README summary.

## Technical summary
- replace the README's broad "open-source / MIT-style" claim with wording that points readers at the checked-in license notices
- expand the README license section to link the inherited Blitz3D core notice at `src/blitzrc/LICENSE.TXT`
- add `LICENSES.md` as a pointer map to the authoritative license files for `src/blitzrc`, `libogg`, `libvorbis`, and the bundled FreeImage tree
- validation: verified every linked notice path exists and ran `git diff --check`
- breaking changes: none

## Additional notes
- Trade-off: this documents the current tree honestly without inventing a new top-level license file or relicensing the repo.
- Intentionally deferred: any repo-wide licensing decision or new canonical root `LICENSE` artifact should be made explicitly by maintainers, not inferred in an automation pass.
- Remaining gap: GitHub still shows no repository license metadata until the project chooses and adds a root-level license file or equivalent canonical licensing surface.
