### PR TITLE
runtime: render-path NaN guards and resource hygiene (Track O)

### DIFF
--- a/src/blitzrc/bbruntime/bbblitz3d.cpp
+++ b/src/blitzrc/bbruntime/bbblitz3d.cpp
@@ -643,6 +643,18 @@ Texture *  bbCreateTexture( int w,int h,int flags,int frames ){
 		} else {
 			errorLog.push_back(std::string("CreateTexture: Illegal number of texture frames"));
 		}
+		// Refuse to allocate a Texture with frames<=0; the underlying
+		// driver path either over-allocates (negative -> huge size_t
+		// cast) or no-ops then crashes on the first frame access.
+		return 0;
+	}
+	if ( w<=0 || h<=0 ){
+		if (debug) {
+			RTEX( "Illegal texture dimensions" );
+		} else {
+			errorLog.push_back(std::string("CreateTexture: Illegal texture dimensions"));
+		}
+		return 0;
 	}
 	Texture *t=d_new Texture( w,h,flags,frames );
 	texture_set.insert( t );
@@ -770,11 +782,11 @@ Brush *  bbCreateBrush( float r,float g,float b ){
 Brush *  bbLoadBrush( BBStr *file,int flags,float u_scale,float v_scale ){
 	if (!debug3d("LoadBrush")) return 0;
 	Texture t( *file,flags );
-	delete file;if( !t.getCanvas(0) ) return 0;
+	delete file;
+	if( !t.getCanvas(0) ) return 0;
 	if( u_scale!=1 || v_scale!=1 ) t.setScale( 1/u_scale,1/v_scale );
 	Brush *br=bbCreateBrush( 255,255,255 );
 	br->setTexture( 0,t,0 );
-	delete file;
 	return br;
 }
 
@@ -1247,6 +1259,10 @@ int  bbCameraProject( Camera *c,float x,float y,float z ){
 		float fr=c->getFrustumFar();
 		float nr_w=c->getFrustumWidth();
 		float nr_h=c->getFrustumHeight();
+		// Frustum width/height of 0 (or near-0) leaves the divide
+		// producing +/-inf and ProjectedX/Y returning NaN forever. Bail
+		// rather than poison subsequent draws.
+		if( nr_w<1e-8f || nr_h<1e-8f ){ projected=Vector(); return 0; }
 		projected=Vector( (v.x/nr_w+.5f)*vp_w,(.5f-v.y/nr_h)*vp_h,nr );
 		return 1;
 	}
@@ -1259,7 +1275,8 @@ int  bbCameraProject( Camera *c,float x,float y,float z ){
 			float fr=c->getFrustumFar();
 			float nr_w=c->getFrustumWidth();
 			float nr_h=c->getFrustumHeight();
-			projected=Vector( 
+			if( nr_w<1e-8f || nr_h<1e-8f ){ projected=Vector(); return 0; }
+			projected=Vector(
 				(v.x*nr/v.z/nr_w+.5f)*vp_w,
 				(.5f-v.y*nr/v.z/nr_h)*vp_h,nr );
 			return 1;
@@ -1580,6 +1597,11 @@ static Vector terrainVector( Terrain *t,float x,float y,float z ){
 
 Entity *  bbCreateTerrain( int n,Entity *p ){
 	if (!debugParent(p,"CreateTerrain")) return 0;
+	// Guard before the shift loop: n<=0 would spin until shift>=31 and
+	// then (1<<shift) silently wraps to INT_MIN, leaving the != check
+	// satisfied only by chance and the allocated Terrain unusable.
+	if( n<=0 ) RTEX( "Illegal terrain size" );
+	if( n>4096 ) RTEX( "Illegal terrain size" );
 	int shift=0;
 	while( (1<<shift)<n ) ++shift;
 	if( (1<<shift)!=n ) RTEX( "Illegal terrain size" );

--- a/src/blitzrc/bbruntime/bbgraphics.cpp
+++ b/src/blitzrc/bbruntime/bbgraphics.cpp
@@ -179,7 +179,14 @@ static gxCanvas *tformCanvas( gxCanvas *c,float m[2][2],int x_handle,int y_handl
 
 	vec2 v,v0,v1,v2,v3;
 	float i[2][2];
-	float dt=1.0f/(m[0][0]*m[1][1]-m[1][0]*m[0][1]);
+	// A degenerate transform (e.g. ScaleImage by 0, or a 90deg rotation
+	// that collapsed to a singular matrix via precision loss) sends det
+	// to 0 and the inverse to +/-inf. Refuse and return null so callers
+	// surface this as a no-op rather than rendering garbage from a
+	// poisoned canvas.
+	float det = m[0][0]*m[1][1]-m[1][0]*m[0][1];
+	if( det>-1e-8f && det<1e-8f ) return 0;
+	float dt=1.0f/det;
 	i[0][0]=dt*m[1][1];i[1][0]=-dt*m[1][0];
 	i[0][1]=-dt*m[0][1];i[1][1]=dt*m[0][0];
 
@@ -686,6 +693,7 @@ gxMovie *bbOpenMovie( BBStr *s ){
 }
 
 int bbDrawMovie( gxMovie *movie,int x,int y,int w,int h ){
+	if( !movie ) return 0;
 	if( w<0 ) w=movie->getWidth();
 	if( h<0 ) h=movie->getHeight();
 	int playing=movie->draw( gx_canvas,x,y,w,h );
@@ -694,18 +702,22 @@ int bbDrawMovie( gxMovie *movie,int x,int y,int w,int h ){
 }
 
 int bbMovieWidth( gxMovie *movie ){
+	if( !movie ) return 0;
 	return movie->getWidth();
 }
 
 int bbMovieHeight( gxMovie *movie ){
+	if( !movie ) return 0;
 	return movie->getHeight();
 }
 
 int bbMoviePlaying( gxMovie *movie ){
+	if( !movie ) return 0;
 	return movie->isPlaying();
 }
 
 void bbCloseMovie( gxMovie *movie ){
+	if( !movie ) return;
 	gx_graphics->closeMovie( movie );
 }
 


### PR DESCRIPTION
## Summary
Engine-level guards in the C++ runtime for paths that previously produced double-free, NaN, or null-deref.

- bbLoadBrush: removed the duplicate "delete file" of the BBStr argument (the first delete already freed it; the second corrupted the small-string allocator)
- bbCreateTexture: frames<=0 now returns 0 instead of logging and continuing; w<=0 / h<=0 added
- bbCreateTerrain: refuses n<=0 up front (the shift loop silently produced INT_MIN on negative input) and caps n at 4096
- tformCanvas: near-zero determinant returns null instead of inverting to inf
- bbCameraProject: frustum width/height near 0 returns 0 with projected=(0,0,0) instead of poisoning every subsequent ProjectedX/Y
- Movie API (bbDrawMovie/bbMovieWidth/Height/Playing/bbCloseMovie): null-check the movie pointer instead of dereferencing 0 from a failed OpenMovie

## Test plan
- [ ] Build passes with 0 errors (verified locally)
- [ ] BlitzForge tests pass