### PR TITLE
runtime: refcount underflow + bank bounds + assert semantics (EE/GG/HH wave 1)

### DIFF
--- a/src/blitzrc/bbruntime/basic.cpp
+++ b/src/blitzrc/bbruntime/basic.cpp
@@ -553,6 +553,10 @@ BBStr *_bbObjTypeName( int ptr ){
 }
 
 int _bbAssertTrue(int t) {
+	// Round 4 audit: return semantics used to be `t > 0` which reports
+	// a *negative* int as failed (a perfectly valid truthy value in Blitz,
+	// e.g. the -1 result of a "True" comparison). Treat any non-zero
+	// value as truthy, matching the Blitz convention everywhere else.
 	if (t == 0) {
 		if (test) {
 			gx_runtime->testFailed = true;
@@ -566,7 +570,7 @@ int _bbAssertTrue(int t) {
 			gx_runtime->debugLog("Failed assertion.");
 		}
 	}
-	return t > 0;
+	return t != 0;
 }
 
 int _bbGetFunctionPointer() {
@@ -681,11 +685,23 @@ int _bbRelease(int vPtr, const char *s) {
 		return 0;
 	}
 
-	//cout << "released ref " << vPtr << " " << s << endl;
-	int count = --reference_map[vPtr];
+	// Round 4 audit: `int count = --reference_map[vPtr]` used to default-
+	// construct the slot to 0 when vPtr had never been referenced, then
+	// decrement to -1 -- which trips `count < 1` and (with GC on) frees
+	// memory that the refcount system never owned. That happened any time
+	// a release path ran against a stale handle, an uninitialised local,
+	// or an object assigned from outside the refcount machinery. Now
+	// treat "not present" as a no-op rather than synthesising an erroneous
+	// release.
+	auto it = reference_map.find(vPtr);
+	if (it == reference_map.end()) {
+		return vPtr;
+	}
+
+	int count = --(it->second);
 
 	if (count < 1) {
-		reference_map.erase(vPtr);
+		reference_map.erase(it);
 
 		if (gcEnabled && count == 0) {
 			//cout << "deleting ref" << endl;

--- a/src/blitzrc/bbruntime/bbbank.cpp
+++ b/src/blitzrc/bbruntime/bbbank.cpp
@@ -49,11 +49,17 @@ static inline bool debugBank( bbBank *b,const char* a ){
 }
 
 static inline bool debugBank( bbBank *b,int offset,const char* a ){
+	// Negative offsets used to skip the bound check entirely (the size
+	// comparison is signed; a negative `offset` is < `b->size` so passes).
+	// Combined with `bbCopyBank`'s `src_p+count-1` arithmetic that meant
+	// `count <= 0` could feed `memmove` a wrapped huge size_t and copy
+	// gigabytes -- arbitrary read/write from inside a Blitz program.
+	// Reject negative offsets up front.
 	if( debug ){
 		if (!debugBank( b,"" )) {
 			return false;
 		}
-		if( offset>=b->size ) {
+		if( offset<0 || offset>=b->size ) {
 			RTEX( "Offset out of range" );
 			return false;
 		}
@@ -61,7 +67,7 @@ static inline bool debugBank( bbBank *b,int offset,const char* a ){
 		if (!debugBank( b,a )) {
 			return false;
 		}
-		if( offset>=b->size ) {
+		if( offset<0 || offset>=b->size ) {
 			errorLog.push_back( std::string(a)+std::string(": Offset out of range"));
 			return false;
 		}
@@ -90,10 +96,19 @@ void  bbResizeBank( bbBank *b,int size ){
 }
 
 void  bbCopyBank( bbBank *src,int src_p,bbBank *dest,int dest_p,int count ){
-	//if( debug ){
+	// Round 4 audit: this used to validate `src_p+count-1` and
+	// `dest_p+count-1` directly. A negative `count` produced a negative
+	// composite that bypassed the bound check (since
+	// `src_p+count-1 < b->size` trivially holds for huge negatives), and
+	// `memmove(..., count)` casts count to size_t -- so negative count
+	// becomes a huge positive copy size and reads/writes far past either
+	// bank, an arbitrary read/write primitive from inside a Blitz
+	// program. Reject up front.
+	if( count <= 0 ) return;
+	if (!debugBank( src,src_p,"CopyBank (src)" )) return;
 	if (!debugBank( src,src_p+count-1,"CopyBank (src)" )) return;
+	if (!debugBank( dest,dest_p,"CopyBank (dest)")) return;
 	if (!debugBank( dest,dest_p+count-1,"CopyBank (dest)")) return;
-	//}
 	memmove( dest->data+dest_p,src->data+src_p,count );
 }
 


### PR DESCRIPTION
Scoped slice of Round 4's BlitzForge findings. The remaining items in each track (parameter refcount in declnode/node, deleteVars struct double-release, _bbVectorRelease type-erasure UB, Recast runtime type check, ARM64 32-bit codegen, _bbThrow va_list lifetime, _bbCallFunctionPointer ESP asm) are deeper structural changes that warrant new tests under tests/ first.

This PR ships the three safest items:

**EE #5 -- `_bbRelease` default-map underflow**
`int count = --reference_map[vPtr]` default-constructed the slot to 0 when `vPtr` had never been referenced, then decremented to -1 -- trips `count < 1` and (with GC on) frees memory the refcount system never owned. Any release path running against a stale handle / uninit local / object assigned from outside the refcount machinery was free heap-corruption. Now finds the entry first; "not present" is a no-op.

**GG #8 -- bbBank / bbCopyBank negative-offset and negative-count**
Original `offset >= b->size` is a signed comparison; negative offset trivially passes, then `b->data + offset` reads/writes outside the bank. `bbCopyBank`'s `src_p + count - 1` arithmetic with negative count fed `memmove` a wrapped huge size_t and copied gigabytes -- arbitrary read/write from inside a Blitz program. Now reject negative offsets in `debugBank` + negative-or-zero count in `bbCopyBank`.

**HH #9 -- `_bbAssertTrue` return semantics**
Returned `t > 0` instead of `t != 0`. Reports a negative int as a failed assertion (e.g. the -1 result of a Blitz comparison). Now `t != 0`.

## Test plan
- [ ] Build green (verified -- 0 errors locally)
- [ ] `test.bat` passes (verified)
- [ ] Manual: write a small Blitz program that `PeekByte`s a bank at offset `-1` -> RTEX instead of read past start
- [ ] Manual: `CopyBank` with count `-1` -> no-op instead of arbitrary copy