### PR TITLE
codegen: getShift unsigned shift + bank Peek/Poke memcpy + tighten Poke bounds

### DIFF
--- a/src/blitzrc/bbruntime/bbbank.cpp
+++ b/src/blitzrc/bbruntime/bbbank.cpp
@@ -117,19 +117,33 @@ int  bbPeekByte( bbBank *b,int offset ){
 	return *(unsigned char*)(b->data+offset);
 }
 
+// Peek/Poke use memcpy rather than direct misaligned dereference. A bank
+// stores raw bytes at arbitrary offsets, so reading `*(int*)(data+offset)`
+// is unaligned for almost every offset that isn't a multiple of 4. x86
+// allows unaligned loads silently; ARM64 (and stricter platforms) can
+// trap. memcpy compiles to the same single load/store on platforms that
+// support unaligned access and to a safe byte-by-byte read where they
+// don't.
+
 int  bbPeekShort( bbBank *b,int offset ){
 	if (!debugBank( b,offset+1,"PeekShort")) return 0;
-	return *(unsigned short*)(b->data+offset);
+	unsigned short v;
+	memcpy( &v,b->data+offset,sizeof v );
+	return v;
 }
 
 int  bbPeekInt( bbBank *b,int offset ){
 	if (!debugBank( b,offset+3,"PeekInt")) return 0;
-	return *(int*)(b->data+offset);
+	int v;
+	memcpy( &v,b->data+offset,sizeof v );
+	return v;
 }
 
 float  bbPeekFloat( bbBank *b,int offset ){
 	if (!debugBank( b,offset+3,"PeekFloat")) return 0;
-	return *(float*)(b->data+offset);
+	float v;
+	memcpy( &v,b->data+offset,sizeof v );
+	return v;
 }
 
 void  bbPokeByte( bbBank *b,int offset,int value ){
@@ -138,18 +152,19 @@ void  bbPokeByte( bbBank *b,int offset,int value ){
 }
 
 void  bbPokeShort( bbBank *b,int offset,int value ){
-	if (!debugBank( b,offset,"PokeShort")) return;
-	*(unsigned short*)(b->data+offset)=value;
+	if (!debugBank( b,offset+1,"PokeShort")) return;
+	unsigned short v = static_cast<unsigned short>(value);
+	memcpy( b->data+offset,&v,sizeof v );
 }
 
 void  bbPokeInt( bbBank *b,int offset,int value ){
-	if (!debugBank( b,offset,"PokeInt")) return;
-	*(int*)(b->data+offset)=value;
+	if (!debugBank( b,offset+3,"PokeInt")) return;
+	memcpy( b->data+offset,&value,sizeof value );
 }
 
 void  bbPokeFloat( bbBank *b,int offset,float value ){
-	if (!debugBank( b,offset,"PokeFloat")) return;
-	*(float*)(b->data+offset)=value;
+	if (!debugBank( b,offset+3,"PokeFloat")) return;
+	memcpy( b->data+offset,&value,sizeof value );
 }
 
 int   bbReadBytes( bbBank *b,bbStream *s,int offset,int count ){

--- a/src/blitzrc/compiler/codegen_x86/codegen_x86.cpp
+++ b/src/blitzrc/compiler/codegen_x86/codegen_x86.cpp
@@ -37,8 +37,14 @@ static bool getShift( int n,int &shift ){
 	return false;
 #endif
 
+	// `1 << 31` on a signed int is UB per the C++ standard (signed
+	// overflow); the compiler is free to optimise it as if it can't
+	// happen, which historically caused the loop to skip the n=INT_MIN
+	// case and miss a valid shift opportunity. Use an unsigned shift
+	// and compare against the unsigned representation of n.
+	unsigned un = static_cast<unsigned>(n);
 	for( shift=0;shift<32;++shift ){
-		if( (1<<shift)==n ) return true;
+		if( (1u<<shift)==un ) return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Three small carry-over fixes flagged in the Round 4 audit's "suspicious / worth flagging" list. Two commits:

### getShift signed-overflow UB (codegen_x86)
`1 << 31` on a signed int is UB per the C++ standard. Compilers are free to assume it can't happen and skip the iteration for `n == INT_MIN`, which means the MUL/SHL fast-path silently misses that case. Use unsigned shift and compare against the unsigned representation of `n`.

### bank Peek/Poke memcpy + tighter Poke bound checks (bbruntime/bbbank.cpp)
Peek/Poke directly dereferenced `(unsigned short*)` / `(int*)` / `(float*)` on a `(char*)+offset` address. A bank stores raw bytes at arbitrary offsets, so almost every offset that isn't 4-aligned produces a misaligned load/store -- x86 silently allows it, ARM64 (and stricter platforms) can trap. memcpy gives a portable single load/store with no runtime cost.

Also tightens PokeShort/Int/Float bound checks to match the corresponding Peek call (e.g. PokeInt used to debugBank with `offset` but writes 4 bytes -- allowed 3 bytes past end). Peek had this right; Poke was missing it.

## Test plan
- [ ] Build green locally (verified -- 0 errors)
- [ ] `test.bat` passes (verified)