### PR TITLE
runtime: movie + OGG load lifetime + null guards (Track RR wave 1)

### DIFF
--- a/src/blitzrc/gxruntime/gxchannel.cpp
+++ b/src/blitzrc/gxruntime/gxchannel.cpp
@@ -168,16 +168,27 @@ static void streamOGG(const std::string &filename,bool isPanned,
 	int endian = 0;
 	int bitStream;
 	long bytes;
-	char* arry = new char[4096];
 	FILE *f;
 	f=fopen(filename.c_str(),"rb");
 	if (f==nullptr) {
 		return;
 	}
+	// Move arry allocation past fopen so a failed open doesn't leak it
+	char* arry = new char[4096];
 	vorbis_info *pInfo;
 	OggVorbis_File oggfile;
-	ov_open(f,&oggfile,"",0);
+	// Check ov_open + ov_info; failures used to deref null pInfo.
+	if( ov_open(f,&oggfile,"",0) != 0 ){
+		delete[] arry;
+		fclose(f);
+		return;
+	}
 	pInfo = ov_info(&oggfile,-1);
+	if (!pInfo) {
+		delete[] arry;
+		ov_clear(&oggfile);
+		return;
+	}
 	if (pInfo->channels == 1) {
 		format = AL_FORMAT_MONO16;
 	} else {

--- a/src/blitzrc/gxruntime/gxgraphics.cpp
+++ b/src/blitzrc/gxruntime/gxgraphics.cpp
@@ -168,10 +168,18 @@ gxMovie *gxGraphics::openMovie( const string &file,int flags ){
 
 				iam_stream->AddMediaStream( NULL,&MSPID_PrimaryAudio,AMMSF_ADDDEFAULTRENDERER,NULL );
 
-				WCHAR *path=new WCHAR[ file.size()+1 ];
-				MultiByteToWideChar( CP_ACP,0,file.c_str(),-1,path,sizeof(WCHAR)*(file.size()+1) );
-				int n=iam_stream->OpenFile( path,0 );
-				delete path;
+				// MultiByteToWideChar's 6th arg is the destination buffer
+				// size *in WCHARs*, not bytes. Passing
+				// sizeof(WCHAR)*(file.size()+1) over-counted by 2x and let
+				// MBToWC write past the buffer when the input length was
+				// near the boundary. The matching `delete path` (not
+				// `delete[]`) leaked the path on every Movie open AND was
+				// UB per the C++ standard (mismatched new[]/delete).
+				int wbufSize = (int)file.size() + 1;
+				WCHAR *path = new WCHAR[ wbufSize ];
+				MultiByteToWideChar( CP_ACP, 0, file.c_str(), -1, path, wbufSize );
+				int n = iam_stream->OpenFile( path, 0 );
+				delete[] path;
 
 				if( n==S_OK ){
 					gxMovie *movie=d_new gxMovie( this,iam_stream );

--- a/src/blitzrc/gxruntime/gxmovie.cpp
+++ b/src/blitzrc/gxruntime/gxmovie.cpp
@@ -4,39 +4,48 @@
 #include "gxgraphics.h"
 
 gxMovie::gxMovie( gxGraphics *g,IMultiMediaStream *mm )
-:gfx(g),mm_stream( mm ),playing(true){
+:gfx(g),mm_stream( mm ),playing(true),
+ vid_stream(0),dd_stream(0),dd_surf(0),dd_sample(0),canvas(0){
 
-	mm_stream->GetMediaStream( MSPID_PrimaryVideo,&vid_stream );
-	vid_stream->QueryInterface( IID_IDirectDrawMediaStream,(void**)&dd_stream );
+	// Every COM call below used to be unchecked: a failure (codec
+	// missing, no audio device, surface query rejected) silently left
+	// a null pointer that the subsequent call crashed on. Check each
+	// HRESULT and bail to a non-playing state on any failure so the
+	// dtor can release whatever did get allocated.
+	if( mm_stream->GetMediaStream( MSPID_PrimaryVideo,&vid_stream )!=S_OK || !vid_stream ){ playing=false; return; }
+	if( vid_stream->QueryInterface( IID_IDirectDrawMediaStream,(void**)&dd_stream )!=S_OK || !dd_stream ){ playing=false; return; }
 
 	DDSURFACEDESC desc={sizeof(desc)};
-	dd_stream->GetFormat( &desc,0,0,0 );
+	if( dd_stream->GetFormat( &desc,0,0,0 )!=S_OK ){ playing=false; return; }
 
 	canvas=gfx->createCanvas( desc.dwWidth,desc.dwHeight,0 );	//gxCanvas::CANVAS_NONDISPLAY );
-	canvas->getSurface()->QueryInterface( IID_IDirectDrawSurface,(void**)&dd_surf );
+	if( !canvas ){ playing=false; return; }
+	if( canvas->getSurface()->QueryInterface( IID_IDirectDrawSurface,(void**)&dd_surf )!=S_OK || !dd_surf ){ playing=false; return; }
 
 	src_rect.left=src_rect.top=0;
 	src_rect.right=desc.dwWidth;src_rect.bottom=desc.dwHeight;
 
-	dd_stream->CreateSample( dd_surf,&src_rect,0,&dd_sample );
+	if( dd_stream->CreateSample( dd_surf,&src_rect,0,&dd_sample )!=S_OK || !dd_sample ){ playing=false; return; }
 
 	mm_stream->SetState( STREAMSTATE_RUN );
 }
 
 gxMovie::~gxMovie(){
-	mm_stream->SetState( STREAMSTATE_STOP );
+	if( mm_stream ) mm_stream->SetState( STREAMSTATE_STOP );
 
-	dd_sample->Release();
-	dd_surf->Release();
-	dd_stream->Release();
-	vid_stream->Release();
-	mm_stream->Release();
+	// Null-check each release path -- ctor may have bailed partway.
+	if( dd_sample ) dd_sample->Release();
+	if( dd_surf ) dd_surf->Release();
+	if( dd_stream ) dd_stream->Release();
+	if( vid_stream ) vid_stream->Release();
+	if( mm_stream ) mm_stream->Release();
 
-	gfx->freeCanvas( canvas );
+	if( canvas ) gfx->freeCanvas( canvas );
 }
 
 bool gxMovie::draw( gxCanvas *dest,int x,int y,int w,int h ){
 	if( !playing ) return false;
+	if( !dd_sample ){ playing=false; return false; }
 	if( !dd_sample->Update( 0,0,0,0 ) ){
 		RECT dest_rect={x,y,x+w,y+h};
 		dest->getSurface()->Blt( &dest_rect,canvas->getSurface(),&src_rect,DDBLT_WAIT,0 );

--- a/src/blitzrc/gxruntime/gxsound.cpp
+++ b/src/blitzrc/gxruntime/gxsound.cpp
@@ -41,25 +41,38 @@ bool gxSoundSample::loadOGG(const std::string &filename,std::vector<char> &buffe
 	int endian = 0;
 	int bitStream;
 	long bytes;
-	char* arry = new char[4096];
 	FILE *f;
 	f=fopen(filename.c_str(),"rb");
 	if (f==nullptr) {
 		return false;
 	}
+	// Move the 4KB arry allocation past the open: the previous order
+	// leaked it whenever fopen failed (early return below before the
+	// matching delete[]).
+	char* arry = new char[4096];
 	vorbis_info *pInfo;
 	OggVorbis_File oggfile;
-	ov_open(f,&oggfile,"",0);
-	pInfo = ov_info(&oggfile,-1);
-	if (pInfo) {
-		if (pInfo->channels == 1) {
-			format = AL_FORMAT_MONO16;
-		}
-		else {
-			format = AL_FORMAT_STEREO16;
-		}
-		freq = pInfo->rate;
+	// ov_open's return value used to be ignored: on failure (corrupt
+	// header, not actually an Ogg, codec missing) ov_info() returns
+	// null and the original code dereferenced pInfo->channels.
+	if( ov_open(f,&oggfile,"",0) != 0 ){
+		delete[] arry;
+		fclose(f);
+		return false;
 	}
+	pInfo = ov_info(&oggfile,-1);
+	if (!pInfo) {
+		delete[] arry;
+		ov_clear(&oggfile);
+		return false;
+	}
+	if (pInfo->channels == 1) {
+		format = AL_FORMAT_MONO16;
+	}
+	else {
+		format = AL_FORMAT_STEREO16;
+	}
+	freq = pInfo->rate;
 	int div = 1;
 	if (isPanned && format==AL_FORMAT_STEREO16) {
 		//OpenAL does not perform automatic panning or attenuation with stereo tracks


### PR DESCRIPTION
Round 5 audit's contained gxruntime fixes:

### `gxgraphics::openMovie`
- `delete path` -> `delete[] path` (was UB per the C++ standard, mismatched new[]/delete)
- `MultiByteToWideChar` size was `sizeof(WCHAR) * (file.size()+1)` -- the 6th arg is the destination size **in WCHARs, not bytes**, so this over-counted 2x and let MBToWC write past the buffer when the input length was near the boundary

### `gxMovie` ctor + draw
- Every COM HRESULT (GetMediaStream / QueryInterface / GetFormat / CreateSample) was unchecked. A failure (codec missing, no audio device, surface query rejected) silently left a null pointer that the subsequent call crashed on. Each is now checked; ctor bails to a non-playing state on any failure.
- All member pointers default-init so the dtor's now-null-checked Release calls are safe after partial construction.
- `draw` null-checks dd_sample before dereferencing.

### `gxsound::loadOGG` + `gxchannel::streamOGG`
- `ov_open` return value was ignored: on failure (corrupt header, not actually an Ogg) `ov_info` returns null and the original code dereferenced `pInfo->channels`. Now check `ov_open` HRESULT, null-check `pInfo`, clean up `arry` on failure paths.
- 4KB `arry` allocation moved past `fopen` so a failed open doesn't leak it.

## Deferred to wave 2
joystick axis overflow + deadzone, gxInput SetDataFormat fallback, gxAudio dtor busy-spin, MM timer race, ShellExecute temporary, callDll static save_esp, DDS chunk overflow, ddutil abort(). Each warrants its own focused look.

## Test plan
- [ ] Build green (verified, 0 errors)
- [ ] BlitzForge tests pass (verified)