### PR TITLE
runtime: bbReadString bounds the captured length to actually-read bytes

### DIFF
--- a/src/blitzrc/bbruntime/bbstream.cpp
+++ b/src/blitzrc/bbruntime/bbstream.cpp
@@ -73,8 +73,16 @@ BBStr *bbReadString( bbStream *s ){
 			return str;
 		}
 		char *buff=d_new char[len];
-		if( s->read( buff,len ) ){
-			*str=string( buff,len );
+		// Capture the actual byte count returned by read() and bound the
+		// resulting string to it. Previously the code used `len`
+		// unconditionally, so a short / truncated read left the tail of
+		// `buff` uninitialised and `string(buff, len)` then captured
+		// whatever bytes the allocator handed us -- a stack/heap info
+		// leak into BASIC string content.
+		int got = s->read( buff, len );
+		if( got > 0 ){
+			if( got > len ) got = len;
+			*str=string( buff, got );
 		}
 		delete[] buff;
 	}


### PR DESCRIPTION
Round 5 audit info-leak finding.

`bbReadString` allocated `len` bytes via `d_new char[len]`, then called `s->read(buff, len)` ignoring the return value, then constructed a `string(buff, len)`. A partial read (truncated file, EOF mid-string, slow network stream returning less than requested) left the tail of `buff` uninitialised, and the resulting BASIC string captured whatever bytes the heap allocator happened to hand us -- a stack/heap content leak into the BASIC string namespace, observable from any Blitz program that prints or sends the read result.

Capture the actual read count and bound the constructed string to it. `read()` returning 0 / negative continues to produce an empty string (matching prior behaviour for unreadable input).

## Test plan
- [ ] Build green (verified)
- [ ] Tests pass (verified)