### PR TITLE
gxruntime: ShellExecute temporary + ddutil abort()->bail (RR wave 2)

### DIFF
--- a/src/blitzrc/gxruntime/ddutil.cpp
+++ b/src/blitzrc/gxruntime/ddutil.cpp
@@ -168,12 +168,26 @@ void ddUtil::buildMipMaps( ddSurf *surf ){
 	while( src->GetAttachedSurface( &caps,&dest )>=0 ){
 
 		DDSURFACEDESC2 src_desc={sizeof(src_desc)};
-		if( src->Lock( 0,&src_desc,DDLOCK_WAIT,0 )<0 ) abort();
+		// Lock failure is common in practice -- alt-tabbing puts the
+		// DirectDraw surfaces into a "lost" state and Lock returns
+		// DDERR_SURFACELOST. The previous code called abort() which
+		// terminated the user's app with no warning every time they
+		// alt-tabbed during a mip-map rebuild. Bail out of the loop
+		// instead; the surface manager will recreate the mip chain
+		// on the next restore().
+		if( src->Lock( 0,&src_desc,DDLOCK_WAIT,0 )<0 ){
+			dest->Release();
+			return;
+		}
 		unsigned char *src_p=(unsigned char*)src_desc.lpSurface;
 		PixelFormat src_fmt( src_desc.ddpfPixelFormat );
 
 		DDSURFACEDESC2 dest_desc={sizeof(dest_desc)};
-		if( dest->Lock( 0,&dest_desc,DDLOCK_WAIT,0 )<0 ) abort();
+		if( dest->Lock( 0,&dest_desc,DDLOCK_WAIT,0 )<0 ){
+			src->Unlock( 0 );
+			dest->Release();
+			return;
+		}
 		unsigned char *dest_p=(unsigned char *)dest_desc.lpSurface;
 		PixelFormat dest_fmt( dest_desc.ddpfPixelFormat );
 

--- a/src/blitzrc/gxruntime/gxruntime.cpp
+++ b/src/blitzrc/gxruntime/gxruntime.cpp
@@ -679,6 +679,14 @@ int gxRuntime::execute( const string &cmd_line, const string& provided_params, c
 
 	SetForegroundWindow( GetDesktopWindow() );
 
+	// Bind the working-directory string to a named local first. The
+	// previous form `start_dir.size() ? start_dir.c_str() : getCWD().c_str()`
+	// took the c_str() of a temporary std::string returned by
+	// getCurrentWorkingDirectory(); the temporary was destroyed at the
+	// end of the full-expression, leaving lpDirectory pointing into
+	// freed memory by the time ShellExecuteEx ran.
+	std::string workingDir = start_dir.size() ? start_dir : getCurrentWorkingDirectory();
+
 	SHELLEXECUTEINFO ShExecInfo = { 0 };
 	ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
 	ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
@@ -686,7 +694,7 @@ int gxRuntime::execute( const string &cmd_line, const string& provided_params, c
 	ShExecInfo.lpVerb = "open"; // Use "open" to open files/applications, "runas" to elevate, etc.
 	ShExecInfo.lpFile = cmd.c_str(); // Specify the program to execute
 	ShExecInfo.lpParameters = params.size() ? params.c_str() : ""; // Any parameters if necessary
-	ShExecInfo.lpDirectory = start_dir.size() ? start_dir.c_str() : getCurrentWorkingDirectory().c_str(); // Set the working directory here
+	ShExecInfo.lpDirectory = workingDir.c_str(); // Set the working directory here
 	ShExecInfo.nShow = SW_SHOW;
 	ShExecInfo.hInstApp = NULL;
 


### PR DESCRIPTION
Round 5 audit, two more gxruntime crash paths:

### `gxRuntime::execute` (gxruntime.cpp:689)
`ShExecInfo.lpDirectory` came from a ternary whose false branch was `getCurrentWorkingDirectory().c_str()` -- the c_str() of a temporary std::string. The temporary was destroyed at the end of the full-expression, leaving `lpDirectory` pointing into freed memory by the time `ShellExecuteEx` ran. Bound to a named `workingDir` local first.

### `ddutil::buildMipMaps` (ddutil.cpp:171,176)
Lock failure called `abort()` -- `DDERR_SURFACELOST` is common and recoverable (happens every time the user alt-tabs during a mip rebuild) and `abort()` terminated the app with no warning. Return from the function instead; the surface manager recreates the mip chain on the next `restore()`. Properly Unlock / Release partially-locked surfaces on bail-out paths.

## Test plan
- [ ] Build green (verified)
- [ ] Tests pass (verified)
- [ ] Manual: alt-tab during a heavy mesh-load with mip generation -> app stays up