### PR TITLE
gxinput: drop unconfigured keyboard/mouse on SetDataFormat fail

### DIFF
--- a/src/blitzrc/gxruntime/gxinput.cpp
+++ b/src/blitzrc/gxruntime/gxinput.cpp
@@ -162,13 +162,19 @@ static Keyboard *createKeyboard( gxInput *input ){
 				dword.dwData=32;
 				if( dev->SetProperty( DIPROP_BUFFERSIZE,&dword.diph )>=0 ){
 					return d_new Keyboard( input,dev );
-				}else{
-//					input->runtime->debugInfo( "keyboard: SetProperty failed" );
 				}
+				input->runtime->debugInfo( "keyboard: SetProperty failed" );
 			}else{
-//				input->runtime->debugInfo( "keyboard: SetDataFormat failed" );
+				input->runtime->debugInfo( "keyboard: SetDataFormat failed" );
 			}
-			return d_new Keyboard( input,dev );
+			// Either SetDataFormat or SetProperty failed: the device is
+			// not actually configured for the c_dfDIKeyboard format, so
+			// GetDeviceState / SetEventNotification calls on it would
+			// return junk or fail. Release here instead of returning a
+			// half-configured Keyboard wrapper that callers cannot tell
+			// apart from a working one.
+			dev->Release();
+			return 0;
 
 		}else{
 			input->runtime->debugInfo( "keyboard: SetCooperativeLevel failed" );
@@ -187,10 +193,14 @@ static Mouse *createMouse( gxInput *input ){
 
 			if( dev->SetDataFormat( &c_dfDIMouse )>=0 ){
 				return d_new Mouse( input,dev );
-			}else{
-//				input->runtime->debugInfo( "mouse: SetDataFormat failed" );
 			}
-			return d_new Mouse( input,dev );
+			input->runtime->debugInfo( "mouse: SetDataFormat failed" );
+			// Same rationale as the keyboard path: an unconfigured device
+			// can't be polled safely; release and surface the failure to
+			// the caller rather than returning a Mouse wrapper that looks
+			// functional but never produces real input state.
+			dev->Release();
+			return 0;
 
 		}else{
 			input->runtime->debugInfo( "mouse: SetCooperativeLevel failed" );


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: `createKeyboard()` and `createMouse()` in gxinput.cpp both ran `SetCooperativeLevel` → `SetDataFormat` → (keyboard only) `SetProperty`, but the bottom of each function had an unconditional fallback `return d_new Keyboard/Mouse( input,dev )` that fired even when `SetDataFormat` (or `SetProperty`) had failed. The caller received a wrapper around an **unconfigured** DirectInput device:

- `GetDeviceState` reads junk under the wrong data format.
- The input subsystem silently never delivers events.
- The `SetProperty`-failed path also leaked a wrapped device (the original code's Release was unreachable).

Match the joystick path: on `SetDataFormat` / `SetProperty` failure, call `debugInfo()`, `Release()` the device, return `0`. Callers already handle the null case as \"no keyboard / no mouse\".

No behavior change on the success path; failures now surface to the caller instead of pretending to work.

## Test plan

- [x] BlitzForge full rebuild clean (0 errors).
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)