### PR TITLE
gxaudio: bounded shutdown wait; clamp gxTimer hertz

### DIFF
--- a/src/blitzrc/gxruntime/gxaudio.cpp
+++ b/src/blitzrc/gxruntime/gxaudio.cpp
@@ -37,12 +37,29 @@ gxAudio::~gxAudio(){
 	for (unsigned int i=0;i<SOURCE_COUNT;i++) {
 		if (channels[i]) {
 			channels[i]->stop();
-			while (!channels[i]->canDispose()) {}
+			// Wait for the channel to become disposable (SampleChannel
+			// waits for OpenAL to drop the source out of AL_PLAYING;
+			// StreamChannel waits for the streaming worker to set
+			// markedForDeletion before returning). Two guards on the
+			// original tight loop:
+			//   1) The bare `while (!canDispose()) {}` pegged a core
+			//      during shutdown -- a tight spin with no yield.
+			//   2) If the streaming worker is wedged (stuck I/O, OpenAL
+			//      driver glitch), the loop never returns and the
+			//      destructor hangs the process forever. After ~2s,
+			//      bail and let the channel destructor's own join /
+			//      buffer cleanup handle the rest -- a missed cleanup
+			//      tick beats a frozen shutdown.
+			DWORD canDisposeDeadline = timeGetTime() + 2000;
+			while (!channels[i]->canDispose()) {
+				if ((LONG)(timeGetTime() - canDisposeDeadline) >= 0) break;
+				Sleep(1);
+			}
 			delete channels[i];
 		}
 		alDeleteSources(1,&sources[i]);
 	}
-    
+
     alcMakeContextCurrent(0);
 	alcDestroyContext(context);
     alcCloseDevice(device);

--- a/src/blitzrc/gxruntime/gxtimer.cpp
+++ b/src/blitzrc/gxruntime/gxtimer.cpp
@@ -6,6 +6,12 @@
 gxTimer::gxTimer( gxRuntime *rt,int hertz ):
 runtime(rt),ticks_get(0),ticks_put(0){
 	event=CreateEvent( 0,false,false,0 );
+	// CreateTimer hertz comes from user Blitz code (CreateTimer hz).
+	// `timeSetEvent( 1000/hertz, ... )` would crash on hertz=0 and
+	// produce a runaway 1ms timer on negative values (signed div).
+	// Clamp to [1, 1000] before the divisor and the timer period.
+	if (hertz < 1) hertz = 1;
+	if (hertz > 1000) hertz = 1000;
 	timerID=timeSetEvent( 1000/hertz,0,timerCallback,(DWORD)this,TIME_PERIODIC );
 }
 


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 findings:

### gxAudio destructor busy-spin

```cpp
while (!channels[i]->canDispose()) {}
```

- **Tight spin, no yield** — pegs a CPU on every process shutdown that has channels in flight.
- **No deadline** — `StreamChannel::canDispose()` returns `markedForDeletion`, which the streaming worker sets just before it returns. If that worker is wedged (stuck I/O, OpenAL driver glitch), the destructor never returns and the process hangs on exit.

Add a **2-second deadline** with `Sleep(1)` per iteration. `delete channels[i]` below still does the proper join/cleanup via `~StreamChannel`; we just stop polling for the ready flag.

### gxTimer hertz validation

`gxTimer(rt, hertz)` trusted the user-supplied Blitz `CreateTimer hz` value:

```cpp
timerID = timeSetEvent( 1000/hertz, 0, timerCallback, ..., TIME_PERIODIC );
```

- `hertz = 0` → divide-by-zero crash.
- negative `hertz` → signed-division wraparound producing a runaway 1ms multimedia timer.

Clamp to `[1, 1000]` before computing the period.

## Test plan

- [x] BlitzForge full rebuild clean (0 errors).
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)