### PR TITLE
linker: bounds-check PE resource tree walk (defensive)

### DIFF
--- a/src/blitzrc/linker/image_util.cpp
+++ b/src/blitzrc/linker/image_util.cpp
@@ -129,20 +129,62 @@ static Rsrc *rsrc_root;
 
 static const char *img_file;
 
-static void openRsrcDir( Section *s,int off,Rsrc *p ){
+// Bound the resource tree traversal against the section's actual data
+// size. The original implementation walked Rdir/Rent/Rdat purely by
+// trusting offsets and counts encoded in the section payload, so a
+// malformed .rsrc section (corrupt stub binary, hostile templated DLL)
+// could:
+//   - dereference an Rdir at any offset within memory (data+off OOB),
+//   - iterate dir->num_ids well past the section, reading adjacent heap,
+//   - point dat->addr at any RVA, making src a wild pointer for memcpy,
+//   - request an arbitrary dat->size allocation copied from that wild
+//     pointer (writable-image -> read primitive in the linker DLL),
+//   - or recurse unboundedly via node entries that point back at
+//     themselves (stack exhaustion).
+// The bounds plumbed below are conservative -- legitimate PE resource
+// trees fit well inside them.
+static const int RSRC_MAX_DIR_ENTRIES = 65535;
+static const int RSRC_MAX_DEPTH       = 32;
+
+static bool rsrcRangeInSection( Section *s,int off,int len ){
+	if( off<0 || len<0 ) return false;
+	if( off>s->sect.data_size ) return false;
+	if( len>s->sect.data_size-off ) return false;
+	return true;
+}
+
+static void openRsrcDir( Section *s,int off,Rsrc *p,int depth ){
+	if( depth>RSRC_MAX_DEPTH ) return;
+	if( !rsrcRangeInSection( s,off,sizeof(Rdir) ) ) return;
+
 	char *data=(char*)s->data;
 
 	Rdir *dir=(Rdir*)(data+off);
-	Rent *ent=(Rent*)(dir+1);
+	int total=dir->num_ids;
+	// Also fold num_names (named entries precede id entries in PE
+	// resource tables) so a hostile binary can't drive past data via
+	// an unaccounted name section.
+	total+=dir->num_names;
+	if( total<=0 ) return;
+	if( total>RSRC_MAX_DIR_ENTRIES ) return;
+
+	int ents_off=off+sizeof(Rdir);
+	if( !rsrcRangeInSection( s,ents_off,(int)sizeof(Rent)*total ) ) return;
+
+	Rent *ent=(Rent*)(data+ents_off);
 	for( int k=0;k<dir->num_ids;++ent,++k ){
 		Rsrc *r=d_new Rsrc( ent->id,p );
 		if( ent->data<0 ){	//a node - offset is another dir
-			openRsrcDir( s,ent->data&0x7fffffff,r );
+			openRsrcDir( s,ent->data&0x7fffffff,r,depth+1 );
 		}else{				//a leaf
-			Rdat *dat=(Rdat*)( data+ent->data );
-//			cout<<"dat addr:"<<dat->addr<<" size:"<<dat->size<<endl;
+			int dat_off=ent->data;
+			if( !rsrcRangeInSection( s,dat_off,sizeof(Rdat) ) ) continue;
+			Rdat *dat=(Rdat*)( data+dat_off );
 			int sz=dat->size;
-			void *src=dat->addr-s->sect.virt_addr+data;
+			if( sz<0 || sz>s->sect.data_size ) continue;
+			int src_off=dat->addr-s->sect.virt_addr;
+			if( !rsrcRangeInSection( s,src_off,sz ) ) continue;
+			void *src=data+src_off;
 			void *dest=d_new char[sz];
 			memcpy( dest,src,sz );
 			r->data=dest;
@@ -153,7 +195,7 @@ static void openRsrcDir( Section *s,int off,Rsrc *p ){
 
 static void openRsrcTree( Section *s ){
 	rsrc_root=d_new Rsrc( 0,0 );
-	openRsrcDir( s,0,rsrc_root );
+	openRsrcDir( s,0,rsrc_root,0 );
 }
 
 static int rsrcSize( Rsrc *r ){


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: `openRsrcDir()` in image_util.cpp walked the PE resource tree off the .rsrc section purely by trusting offsets and counts in the payload:

- `data + off`, `data + ent->data`, and `data + (dat->addr - virt_addr)` dereferenced at attacker-influenced offsets.
- Loop iterated `dir->num_ids` unbounded.
- `dat->size` used for both the `d_new char[sz]` allocation and `memcpy(dest, src, sz)`.
- Node entries could recurse `openRsrcDir` unbounded (a node pointing at its own dir → stack exhaustion).

In normal use the .rsrc section comes from BlitzForge's shipped stub DLL so the input is trusted. This is **defense in depth**: a corrupted/replaced stub now produces a quiet bail instead of wild-pointer `memcpy`, runaway allocation, or recursion blowup.

### Bounds added

- `rsrcRangeInSection(off, len)` confirms `[off, off+len)` stays inside `s->sect.data_size` without signed/overflow surprises.
- Every `Rdir`, the trailing `Rent[]` (sized by `num_ids + num_names` so named entries also count), each leaf `Rdat`, and the leaf payload range `[dat->addr - virt_addr, +dat->size)` are checked before deref.
- `num_ids + num_names` capped at **64K**; recursion depth capped at **32**; `dat->size` rejected if negative or larger than the section.

All limits sit well above any legitimate PE resource tree.

### Test plan

- [x] Full BlitzForge rebuild clean (0 errors).
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)