### PR TITLE
gxruntime: per-call save_esp in callDll (drop function-static)

### DIFF
--- a/src/blitzrc/gxruntime/gxruntime.cpp
+++ b/src/blitzrc/gxruntime/gxruntime.cpp
@@ -1279,7 +1279,20 @@ int gxRuntime::callDll( const std::string &dll,const std::string &func,const voi
 		fun_it=t->funcs.insert( make_pair( func,f ) ).first;
 	}
 
-	static void *save_esp;
+	// Saved ESP must be per-call, not a function-static. The original
+	// `static void *save_esp` lived in BSS, so:
+	//   - Recursive callDll (a user library that calls back into a
+	//     Blitz userlib which fires another callDll) clobbered the
+	//     outer call's saved ESP with the inner call's; on inner
+	//     return the outer's restore set ESP to the inner's saved
+	//     value -- stack pointer permanently off.
+	//   - Two threads calling callDll concurrently raced on the same
+	//     slot.
+	// Local stack variable: each invocation owns its own slot, and
+	// EBP-relative addressing (the project builds with /Oy-, so frame
+	// pointers are preserved) keeps the restore site readable even
+	// after the callee returns with an unbalanced ESP.
+	void *save_esp;
 
 	_asm{
 		mov	[save_esp],esp


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: `gxRuntime::callDll` bracketed the userlib call with an ESP save/restore using a function-`static` slot:

```cpp
static void *save_esp;
_asm { mov [save_esp], esp };
int n = fun_it->second(in, in_sz, out, out_sz);
_asm { mov esp, [save_esp] };
```

Because the slot is one shared BSS location, two failure modes:

- **Recursion** — a userlib that re-enters Blitz which fires another `callDll` overwrites the outer call's saved ESP. On inner return, the outer's restore sets ESP to the inner saved value: stack pointer off, outer return chain corrupted.
- **Concurrency** — two threads in `callDll` race on the slot. Same semantic corruption across threads instead of across recursion levels.

Change to a local stack variable. Each invocation owns its own slot, and EBP-relative addressing (project builds with `/Oy-` so frame pointers are preserved) keeps the restore site readable even when the callee returns with an unbalanced ESP.

## Test plan

- [x] BlitzForge full rebuild clean (0 errors).
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)