### PR TITLE
bbruntime: per-BlitzType release dispatch (re-enables testEmbeddedLists)

### DIFF
--- a/src/blitzrc/bbruntime/basic.cpp
+++ b/src/blitzrc/bbruntime/basic.cpp
@@ -38,8 +38,17 @@ static int next_handle;
 static map<int,BBObj*> handle_map;
 static map<BBObj*,int> object_map;
 
-//reference counts
-static map<int, int> reference_map;
+//reference counts. The slot also carries a type label set at object
+//creation time so _bbRelease can dispatch to the correct destructor
+//even when called via a path that has lost the static type (notably
+//BBList elements, which are type-erased ints once they live inside
+//the std::vector). The label is a `const char*` to a static string
+//literal -- never copied, never freed.
+struct RefSlot {
+	int count;
+	const char *type;
+};
+static map<int, RefSlot> reference_map;
 
 //garbage collection switch
 static bool gcEnabled = false;
@@ -710,7 +719,22 @@ int _bbReference(int vPtr) {
 	}
 
 	//cout << "added ref " << vPtr << endl;
-	++reference_map[vPtr];
+	++reference_map[vPtr].count;
+	return vPtr;
+}
+
+// Like _bbReference but also stamps the type label on first
+// registration. Used at object-creation sites that know the static
+// type (e.g. _bbNewVector tags "BBList"). Subsequent _bbReference
+// calls on the same pointer preserve the original label.
+int _bbReferenceTyped(int vPtr, const char *type) {
+	if (vPtr == 0) {
+		return 0;
+	}
+
+	RefSlot &slot = reference_map[vPtr];
+	++slot.count;
+	if (slot.type == nullptr) slot.type = type;
 	return vPtr;
 }
 
@@ -732,19 +756,28 @@ int _bbRelease(int vPtr, const char *s) {
 		return vPtr;
 	}
 
-	int count = --(it->second);
+	int count = --(it->second.count);
 
 	if (count < 1) {
+		// Prefer the type stamped at creation time over the caller-
+		// supplied label `s`. Callers that have lost the element's
+		// static type (e.g. _bbVectorRelease, which is dispatched
+		// from inside a type-erased BBList) pass a best-effort
+		// fallback; the registered type is authoritative. Without
+		// this, lists-of-lists drove _bbObjDelete on a vector
+		// pointer (undefined behaviour, see ListTest's
+		// testEmbeddedLists).
+		const char *actualType = it->second.type ? it->second.type : s;
 		reference_map.erase(it);
 
 		if (gcEnabled && count == 0) {
 			//cout << "deleting ref" << endl;
-			if (strcmp(s, "BBCustom") == 0) {
+			if (strcmp(actualType, "BBCustom") == 0) {
 				void* objPtr = reinterpret_cast<void*>(vPtr);
 				BBObj* obj = static_cast<BBObj*>(objPtr);
 
 				_bbObjDelete(obj);
-			} else if (strcmp(s, "BBList") == 0) {
+			} else if (strcmp(actualType, "BBList") == 0) {
 				_bbVectorFree(vPtr);
 			}
 		}
@@ -758,14 +791,18 @@ int _bbReferenceCount(int vPtr) {
 		return 0;
 	}
 
-	return reference_map[vPtr];
+	return reference_map[vPtr].count;
 }
 
 int _bbNewVector() {
 	std::vector<int>* newVec = new std::vector<int>;
 	++listCnt;
 	int ptr = reinterpret_cast<int>(newVec);
-	_bbReference(ptr);
+	// Stamp the type at creation so _bbRelease dispatches via
+	// _bbVectorFree even when the eventual release comes through a
+	// type-erased path (e.g. an outer list freeing its inner-list
+	// elements as nominal "BBCustom").
+	_bbReferenceTyped(ptr, "BBList");
 	return ptr;
 }
 
@@ -803,19 +840,13 @@ int _bbVectorAt(int aPtr, int idx) {
 void _bbVectorRelease(int aPtr, int idx) {
 	int ptr = _bbVectorAt(aPtr, idx);
 	if (ptr != 0) {
-		// NOTE: BBList is type-erased; the element pointer here could be a
-		// BBObj, BBList, BBBank, or any other refcounted handle. The legacy
-		// dynamic_cast<BBObj*> on a non-polymorphic struct is undefined
-		// behaviour, so the value of the cast was effectively "always succeed"
-		// — i.e. every element was released as BBCustom. That works for
-		// BBObj-only lists (the common case) and is what existing tests
-		// assume; lists holding non-BBObj elements (e.g. lists of lists)
-		// invoke _bbObjDelete on garbage memory and may crash. A proper fix
-		// requires per-element type tagging or a runtime label dispatch in
-		// _bbRelease covering all BlitzTypes; both are tracked separately.
-		// For now: keep the existing "release as BBCustom" semantics but
-		// drop the meaningless dynamic_cast so the intent is honest in the
-		// source.
+		// BBList is type-erased; the element pointer here could be a
+		// BBObj, an inner BBList, or any other refcounted handle. We
+		// pass "BBCustom" as a fallback for legacy BBObj-of-X lists,
+		// but _bbRelease prefers the type stamped at object creation
+		// time (e.g. "BBList" for nested lists), so this path now
+		// dispatches correctly for lists-of-lists instead of running
+		// _bbObjDelete on a std::vector pointer.
 		_bbRelease(ptr, "BBCustom");
 	}
 }

--- a/tests/ListTest.bb
+++ b/tests/ListTest.bb
@@ -123,23 +123,14 @@ Test testListInsertRemoveReplace()
     FreeList(testArray)
 End Test
 
-; testEmbeddedLists exercised lists-of-lists, which triggers the type-erasure
-; UB in _bbVectorRelease (it treats every element as BBObj via a dynamic_cast
-; on a non-polymorphic struct). On the previous toolchain it happened to pass
-; because the heap layout never made _bbObjDelete on a vector<int>* dereference
-; into invalid memory; small unrelated allocation changes (e.g. fixing
-; CopyStream's delete[] in this branch) shift the heap and the UB starts
-; crashing. The proper fix is per-BlitzType release dispatch; this test will
-; come back once that lands.
-;
-;Test testEmbeddedLists()
-;    Local testArray.BBList = CreateList()
-;    Local testArray2.BBList = CreateList()
-;    ListAdd(testArray, testArray2)
-;
-;    Local recoveredList.BBList = ListFirst(testArray)
-;    ListAdd(recoveredList, new DTOTest())
-;
-;    FreeList(testArray2)
-;    FreeList(testArray)
-;End Test
+Test testEmbeddedLists()
+    Local testArray.BBList = CreateList()
+    Local testArray2.BBList = CreateList()
+    ListAdd(testArray, testArray2)
+
+    Local recoveredList.BBList = ListFirst(testArray)
+    ListAdd(recoveredList, new DTOTest())
+
+    FreeList(testArray2)
+    FreeList(testArray)
+End Test


### PR DESCRIPTION
## Summary

Closes the long-standing deferred finding: `reference_map` stored only a refcount, and `_bbRelease(ptr, label)` trusted the caller-supplied label for the destructor dispatch:

```cpp
if (label == "BBCustom") _bbObjDelete(ptr as BBObj*);
else if (label == "BBList") _bbVectorFree(ptr);
```

`_bbVectorRelease` (fired when an element is removed from a `BBList`, or when an outer list iterates its elements during `_bbVectorFree`) hardcoded the label as `"BBCustom"` — it had no way to recover the element's static type once it lived as an `int` inside `std::vector<int>`. So:

- For BBObj-only lists (the common case) it worked.
- For lists holding inner BBLists, the outer free called `_bbRelease(innerPtr, "BBCustom")`. Refcount hit zero, dispatch ran `_bbObjDelete` on a `std::vector<int>*` — read+write into arbitrary heap. `testEmbeddedLists` was disabled because of this.

### Change

- `reference_map` becomes `map<int, RefSlot>` where `RefSlot { int count; const char *type; }` — the type label is a `const char*` to a static literal (never copied, never freed).
- New `_bbReferenceTyped(ptr, type)` runtime helper for sites that know the static type at registration time.
- `_bbNewVector` stamps `"BBList"` at creation via `_bbReferenceTyped`.
- `_bbRelease` prefers the stamped type when present and falls back to the caller's label otherwise — BBObj entries that never went through `_bbReferenceTyped` keep working with the codegen's `"BBCustom"` label.

### Test plan

- [x] Re-enabled `testEmbeddedLists` in `tests/ListTest.bb`.
- [x] Full BlitzForge `test.bat` suite passes (all 14 .bb test files).
- [x] rcce2 `test.bat` (the consumer's server-module suite) passes against this build.
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)