### PR TITLE
Recast: runtime IS-A check against target superType chain

### DIFF
--- a/src/blitzrc/compiler/exprnode.cpp
+++ b/src/blitzrc/compiler/exprnode.cpp
@@ -799,6 +799,19 @@ ExprNode *RecastNode::semant( Environ *e ){
 
 TNode *RecastNode::translate( Codegen *g ){
 	TNode *t=expr->translate( g );
+	// Runtime IS-A check against the target type's BBObjType. Recast
+	// is the explicit downcast syntax (e.g. Recast.SecondType(parent))
+	// and used to be a pure no-op -- the compiler just trusted that
+	// the caller knew the dynamic type. A wrong call quietly produced
+	// a misinterpreted pointer that surfaced as a corrupt field read
+	// pages later. _bbObjFromPointer walks the type's superType chain
+	// (see _bbObjIsKindOf in basic.cpp) and returns null on mismatch,
+	// matching the existing Object.X(ptr) semantics. Code that does
+	// `Recast.X(value)` followed by an unconditional field deref will
+	// now hit a clean Null deref instead of a stale-bytes read; the
+	// idiomatic pattern of checking `recasted = Null` afterwards keeps
+	// working.
+	t=call( "__bbObjFromPointer",t,global( "_t"+sem_type->structType()->ident ) );
 	return t;
 }
 

--- a/tests/InheritTest.bb
+++ b/tests/InheritTest.bb
@@ -216,21 +216,23 @@ Test testDoubleCastUpIntegrity()
 End Test
 
 Test testIncorrectCrossCasting()
-    ; Cast down and cast up to wrong type
+    ; Cast down and cast up to a *sibling* type (SecondInherit and
+    ; Inherit both extend Base, but neither is a parent/child of the
+    ; other). Recast now does a runtime IS-A check against the
+    ; target's superType chain (matching Object.X(ptr) semantics), so
+    ; a sibling-cast that previously silently produced a pointer
+    ; with misaligned field offsets now returns Null. The caller is
+    ; expected to check for Null before dereferencing -- the
+    ; idiomatic pattern in the rest of the codebase.
     Local base2.Inherit = new Inherit()
     base2\baseVar = "foo"
     base2\inheritVar = "bar"
 
-    ; Cast down
+    ; Cast down to common parent.
     Local base5.Base = base2
 
-    ; Cast back up
+    ; Cast back up to the *wrong* sibling type. With the runtime
+    ; check this returns Null instead of reinterpreting the bytes.
     Local base9.SecondInherit = Recast.SecondInherit(base5)
-
-    Assert(base9\baseVar = "foo")
-
-    ; Because Recast is memory unsafe the secondInheritVar is in the second memory slot of the object
-    ; where inheritVar was so now the secondInheritVar is showing that value because it is referencing
-    ; the second memory slot.
-    Assert(base9\secondInheritVar = "bar")
+    Assert(base9 = Null)
 End Test


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: `RecastNode::translate` used to be a pure no-op — the compiler trusted that the caller knew the dynamic type. A wrong call (cross-cast to a sibling type, or recast of a value whose dynamic type isn't a subclass of the target) silently produced a pointer with mis-aligned field offsets. Subsequent reads returned bytes from neighbouring fields; writes corrupted them. `InheritTest::testIncorrectCrossCasting` deliberately exercised this and asserted on the resulting garbage.

Route `Recast.X(value)` through `__bbObjFromPointer`, which (via `_bbObjIsKindOf`) walks the value's `BBObjType.superType` chain looking for the target type. Match → return value. Mismatch → return `Null`. Same machinery `Object.X(ptr)` has always used.

### Effect on existing code

- **Upcast** (child → parent): chain walk finds the target — succeeds. Unchanged.
- **Downcast** where the dynamic type really is the child: chain walk finds it — succeeds. Unchanged.
- **Downcast** where the dynamic type is just the parent: chain walk fails — returns `Null`. Previously produced a misinterpreted pointer.
- **Cross-cast** between siblings (both extend same base, neither inherits from the other): chain walk fails — returns `Null`. Previously corrupted field reads.

`testIncorrectCrossCasting` is updated to assert that the sibling recast now returns `Null` instead of misaligned bytes.

## Test plan

- [x] Full BlitzForge `test.bat` suite passes (Inherit, TypeTest, FunctionPointer, GarbageCollection, Try/Throw/Catch, etc.).
- [x] rcce2 `test.bat` server-module suite passes against this build.
- [ ] CI build + macOS smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)