### PR TITLE
fix: preserve Strict locals through Else If parsing

### DIFF
--- a/src/blitzrc/compiler/parser.cpp
+++ b/src/blitzrc/compiler/parser.cpp
@@ -846,7 +846,7 @@ IfNode *Parser::parseIf(vector<string> localIdents){
 	if( toker->curr()==ELSEIF ){
 		int pos=toker->pos();
 		toker->next();
-		IfNode *ifnode=parseIf();
+		IfNode *ifnode=parseIf( localIdents );
 		ifnode->pos=pos;
 		elseOpt=d_new StmtSeqNode( incfile );
 		elseOpt->push_back( ifnode );

--- a/tests/StrictElseIfScopeTest.bb
+++ b/tests/StrictElseIfScopeTest.bb
@@ -1,0 +1,87 @@
+Strict
+EnableGC
+
+Type StrictElseIfScopeSubject
+    Field cat$
+    Field latch%
+
+    Method demo()
+        Local localLatch% = 0
+
+        If self\cat = "a"
+            localLatch = 1
+        Else If self\cat = "b"
+            localLatch = 2
+            If self\cat = "b"
+                localLatch = localLatch + 10
+            End If
+        Else
+            localLatch = 3
+        End If
+
+        self\latch = localLatch
+    End Method
+End Type
+
+Test testStrictLocalReassignmentInElseIf()
+    Local latch% = 0
+
+    If False
+        latch = 1
+    Else If True
+        latch = 2
+    Else
+        latch = 3
+    End If
+
+    Assert(latch = 2)
+End Test
+
+Test testStrictLocalReassignmentInNestedElseIfBlock()
+    Local latch% = 0
+
+    If False
+        latch = 1
+    Else If True
+        If True
+            latch = 4
+        End If
+    Else
+        latch = 3
+    End If
+
+    Assert(latch = 4)
+End Test
+
+Test testStrictMethodLocalReassignmentInElseIf()
+    Local subject.StrictElseIfScopeSubject = new StrictElseIfScopeSubject()
+    subject\cat = "b"
+
+    subject\demo()
+
+    Assert(subject\latch = 12)
+End Test
+
+Test testStrictLocalReassignmentInIfAndElseStillWorks()
+    Local firstLatch% = 0
+    Local elseLatch% = 0
+
+    If True
+        firstLatch = 1
+    Else If False
+        firstLatch = 2
+    Else
+        firstLatch = 3
+    End If
+
+    If False
+        elseLatch = 1
+    Else If False
+        elseLatch = 2
+    Else
+        elseLatch = 3
+    End If
+
+    Assert(firstLatch = 1)
+    Assert(elseLatch = 3)
+End Test


### PR DESCRIPTION
## Non-technical summary

Fixes a Strict-mode compiler bug where a `Local` declared in a function or method could be reassigned inside the first `If` branch and a plain `Else`, but failed inside an `Else If` branch.

This matters for BlitzForge's modern Strict-mode surface: ordinary function-scope locals now behave consistently across all branches, including the rcce2 Loom repro from #61.

Closes #61.

## Technical summary

- Threads inherited `localIdents` through the recursive `Parser::parseIf` path used for `Else If`.
- Adds `tests/StrictElseIfScopeTest.bb` covering:
  - function/test-scope local reassignment inside `Else If`;
  - nested block reassignment inside `Else If`;
  - method-scope local reassignment inside `Else If`;
  - existing first-`If` and plain-`Else` reassignment behavior.

No syntax, runtime ABI, codegen, or non-Strict behavior is intentionally changed.

## Acceptance criteria and test results

- [x] A `.bb` regression test fails on current `develop` with the issue #61 repro shape.
  - Red run before the parser fix: `bin\blitzcc.exe -t tests\StrictElseIfScopeTest.bb` failed with `locallatch assignment should start with local, global or const modifier`.
- [x] The same test passes after the parser change.
  - `bin\blitzcc.exe -t tests\StrictElseIfScopeTest.bb` passed all four test blocks.
- [x] Function/method-scope locals remain assignable in first `If`, `Else If`, nested `Else If` blocks, and plain `Else`.
  - Covered by `tests/StrictElseIfScopeTest.bb`.
- [x] Invalid Strict assignments to undeclared identifiers still fail with the existing diagnostic.
  - Manual negative check against `tmp\StrictUndeclaredNegative.bb` failed as expected with `missing assignment should start with local, global or const modifier`.
- [x] Existing `tests/*.bb` continue to pass.
  - `test.bat` passed.

## Trade-offs and deferred follow-ups

- Kept this to the existing parser local-identifier propagation model instead of redesigning Strict scope tracking.
- Did not implement dynamic method-call expression support or any unrelated parser/codegen work.
- Deferred `_bbAsyncCallFunctionPointer` argument lifetime hardening; it remains a strong future Bug/Reliability increment.

## Breaking changes

None.
