### PR TITLE
Let blitzcc metadata run without runtime DLLs

### DIFF
--- a/src/blitzrc/blitz/main.cpp
+++ b/src/blitzrc/blitz/main.cpp
@@ -169,6 +169,10 @@ static void versInfo(){
 	cout<<"Linker version:"<<verstr(lnk_ver)<<endl;
 }
 
+static void compilerVersInfo(){
+	cout<<"Compiler version:"<<verstr(VERSION)<<endl;
+}
+
 static void demoError(){
 	cout<<"Compiler can not be used standalone in demo version."<<endl;
 	exit(0);
@@ -234,15 +238,6 @@ int _cdecl main( int argc,char *argv[] ){
 		}
 	}
 
-	if (debug) {
-		std::ifstream file("ATTACH", std::ifstream::ate | std::ifstream::binary);
-		if (file.good() && file.tellg() > 0) {
-			bfplatform::showInfoMessage(
-				"Attach Debugger",
-				"Execution is paused so a debugger can be attached if necessary. When you are ready to continue press ok.");
-		}
-	}
-	
 	if( out_file.size() && !in_file.size() ) usageErr();
 
 	if( target.size() ){
@@ -254,7 +249,22 @@ int _cdecl main( int argc,char *argv[] ){
 		target=hostDefaultTargetName();
 	}
 
-	if (in_file[0] == '\"') {
+	if( !in_file.size() && !dumpkeys ){
+		if( showhelp ) showHelp();
+		if( versinfo ) compilerVersInfo();
+		return 0;
+	}
+
+	if (debug) {
+		std::ifstream file("ATTACH", std::ifstream::ate | std::ifstream::binary);
+		if (file.good() && file.tellg() > 0) {
+			bfplatform::showInfoMessage(
+				"Attach Debugger",
+				"Execution is paused so a debugger can be attached if necessary. When you are ready to continue press ok.");
+		}
+	}
+	
+	if (in_file.size() && in_file[0] == '\"') {
 		if (in_file.size() < 3 || in_file[in_file.size() - 1] != '\"') usageErr();
 		in_file = in_file.substr(1, in_file.size() - 2);
 	}

--- a/test.bat
+++ b/test.bat
@@ -7,6 +7,9 @@ set BLITZPATH=%ROOTDIR%
 set FAILED=0
 set SAMPLE=%ROOTDIR%\tests\NumberTest.bb
 
+call :expect_isolated_cli "isolated -h works without DLLs" "Usage:" -h
+call :expect_isolated_cli "isolated -v works without DLLs" "Compiler version:" -v
+call :expect_isolated_cli "isolated bare invocation works without DLLs" ""
 call :expect_success "host alias compiles NumberTest" -c +q -target host "%SAMPLE%"
 call :expect_success "native Windows target compiles NumberTest" -c +q -target windows-x86 "%SAMPLE%"
 call :expect_failure "foreign macOS target is rejected" "Unsupported -target" -c +q -target macos-arm64 "%SAMPLE%"
@@ -61,4 +64,39 @@ if !TARGET_RC! EQU 0 (
     )
 )
 del /q "!TARGET_LOG!" >nul 2>&1
+exit /b 0
+
+:expect_isolated_cli
+set "LABEL=%~1"
+set "EXPECTED=%~2"
+shift /1
+shift /1
+set "CLI_DIR=%TEMP%\blitzforge-cli-%RANDOM%-%RANDOM%"
+set "CLI_LOG=%TEMP%\blitzforge-cli-%RANDOM%-%RANDOM%.log"
+mkdir "!CLI_DIR!" >nul 2>&1
+copy /y "%BLITZPATH%\bin\blitzcc.exe" "!CLI_DIR!\blitzcc.exe" >nul
+if errorlevel 1 (
+    echo CLI contract FAILED: !LABEL! could not stage blitzcc.exe
+    set FAILED=1
+    rmdir /s /q "!CLI_DIR!" >nul 2>&1
+    exit /b 0
+)
+pushd "!CLI_DIR!" >nul
+"!CLI_DIR!\blitzcc.exe" %1 %2 %3 %4 %5 %6 %7 %8 %9 >"!CLI_LOG!" 2>&1
+set "CLI_RC=!ERRORLEVEL!"
+popd >nul
+if !CLI_RC! NEQ 0 (
+    echo CLI contract FAILED: !LABEL! returned !CLI_RC!
+    type "!CLI_LOG!"
+    set FAILED=1
+) else if defined EXPECTED (
+    findstr /C:"!EXPECTED!" "!CLI_LOG!" >nul
+    if errorlevel 1 (
+        echo CLI contract FAILED: !LABEL! did not print !EXPECTED!
+        type "!CLI_LOG!"
+        set FAILED=1
+    )
+)
+del /q "!CLI_LOG!" >nul 2>&1
+rmdir /s /q "!CLI_DIR!" >nul 2>&1
 exit /b 0

--- a/test.sh
+++ b/test.sh
@@ -8,13 +8,56 @@ trap 'rm -rf "${TEST_TMPDIR}"' EXIT
 
 BLITZCC_UNIX="${ROOTDIR}/bin/blitzcc"
 BLITZCC_WIN="${ROOTDIR}/bin/blitzcc.exe"
+BLITZCC_IS_UNIX=0
 if [[ -x "${BLITZCC_UNIX}" ]]; then
   BLITZCC="${BLITZCC_UNIX}"
+  BLITZCC_IS_UNIX=1
 elif [[ -f "${BLITZCC_WIN}" ]]; then
   BLITZCC="${BLITZCC_WIN}"
 else
   echo "blitzcc not found; run ./compile.sh first." >&2
   exit 1
+fi
+
+FAILED=0
+
+run_isolated_cli_expect_success() {
+  local label="$1"
+  local expected="$2"
+  shift 2
+  local isolated_dir="${TEST_TMPDIR}/isolated-${label//[^A-Za-z0-9]/-}"
+  mkdir -p "${isolated_dir}"
+  cp "${BLITZCC}" "${isolated_dir}/blitzcc"
+  chmod +x "${isolated_dir}/blitzcc"
+
+  set +e
+  (
+    cd "${isolated_dir}"
+    ./blitzcc "$@"
+  ) > "${isolated_dir}/cli.out" 2> "${isolated_dir}/cli.err"
+  local rc=$?
+  set -e
+
+  if [[ "${rc}" -ne 0 ]]; then
+    echo "CLI contract FAILED: ${label} returned ${rc}" >&2
+    cat "${isolated_dir}/cli.out" >&2
+    cat "${isolated_dir}/cli.err" >&2
+    FAILED=1
+    return
+  fi
+
+  if [[ -n "${expected}" ]] && ! grep -q "${expected}" "${isolated_dir}/cli.out"; then
+    echo "CLI contract FAILED: ${label} did not print ${expected}" >&2
+    cat "${isolated_dir}/cli.out" >&2
+    cat "${isolated_dir}/cli.err" >&2
+    FAILED=1
+  fi
+}
+
+if [[ "${BLITZCC_IS_UNIX}" -eq 1 ]]; then
+  run_isolated_cli_expect_success "isolated -h works without DLLs" "Usage:" -h
+  run_isolated_cli_expect_success "isolated -v works without DLLs" "Compiler version:" -v
+  run_isolated_cli_expect_success "isolated bare invocation works without DLLs" ""
 fi
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -39,7 +82,6 @@ else
   EXEC_FLAG=()
 fi
 
-FAILED=0
 TARGET_SAMPLE="${TESTDIR}/NumberTest.bb"
 
 run_target_expect_success() {


### PR DESCRIPTION
## Non-technical summary

This fixes `blitzcc` metadata commands so basic CLI discovery works even when the compiler executable is copied or inspected without its runtime/linker DLLs. Users can now run help, version, or a bare invocation without hitting a misleading `Unable to open linker library` failure.

## Technical summary

- Adds a no-source fast path in `src/blitzrc/blitz/main.cpp` after argument parsing and `-target` validation, but before debug attach, source-path normalization, `openLibs()`, or `linkLibs()`.
- Makes `-h`, no-source `-v`, and bare no-source invocation return successfully without loading runtime/linker shared libraries.
- Keeps `-k` / `+k` on the existing runtime-linked path because keyword dumping includes runtime/userlib symbols.
- Guards quoted source normalization so `in_file[0]` is never read when no source was supplied.
- Adds isolated-executable CLI smoke coverage to `test.bat` and Unix-equivalent coverage to `test.sh` when a Unix `bin/blitzcc` is available.

## Implementation plan

Goal: make no-source `blitzcc` metadata modes behave like front-door metadata commands rather than compile commands.

Approach:
1. Add acceptance tests that copy only the compiler executable into a temp directory and assert isolated `-h`, `-v`, and bare invocation succeed.
2. Validate `-target` before no-source success exits so unsupported targets still fail explicitly.
3. Return early for no-source non-keyword metadata commands before debug attach and shared-library loading.
4. Preserve compile, test, and keyword-dump paths on the existing runtime/linker loading flow.

Trade-off: no-source `-v` now reports compiler version only. Rich runtime/linker/debugger version reporting remains available on paths that load the companion libraries; a future explicit version contract could label component availability more precisely.

## Acceptance criteria and test results

- [x] `blitzcc.exe -h` exits 0 and prints usage when only `blitzcc.exe` is staged in a temp directory.
- [x] `blitzcc.exe -v` exits 0 and prints compiler version when only `blitzcc.exe` is staged in a temp directory.
- [x] Bare `blitzcc.exe` exits 0 without loading runtime/linker DLLs.
- [x] `in_file[0]` is not read unless a source path exists.
- [x] Unsupported `-target` validation remains before no-source success exits.
- [x] Normal compile/test behavior still loads runtime/linker and passes the existing `.bb` suite.

Local verification:
- Red check before fix: new isolated Windows CLI checks failed with `Unable to open linker library`.
- `cmd.exe /c compile.bat` passed with 0 errors.
- `cmd.exe /c test.bat` passed (`"Tests passed"`).
- `bash -n test.sh` passed.

## Deferred follow-ups

- Consider a richer `--version` contract that explicitly reports compiler/runtime/linker/debugger component availability.
- The duplicate userlib discovery issue surfaced by reconnaissance remains a separate reliability increment.

## Breaking changes

None. This broadens no-source CLI behavior; compile and keyword-dump behavior remains on the linked runtime path.