### PR TITLE
Own async function-pointer payloads

### DIFF
--- a/src/blitzrc/bbruntime/basic.cpp
+++ b/src/blitzrc/bbruntime/basic.cpp
@@ -619,73 +619,84 @@ T _bbCallFunctionPointer(BBFunction<T> functionPtr, va_list args) {
 	return returnValue;
 }
 
-// KNOWN BUG: on MSVC x86 `va_list` is a `char*` into the *caller's*
-// stack frame. `std::async(std::launch::async, functionPtr, args)`
-// decay-copies the pointer into the worker task, but the worker
-// reads through it after this function has returned and the
-// caller's frame may have been torn down. That's a use-after-free
-// with intermittent symptoms: works in FunctionPointerTest's tight
-// Async-then-Poll-then-Await loops because the launching frame is
-// still live, fails the moment the async handle escapes its
-// launching function (e.g. caller stores the BBThread in a global
-// and returns).
-//
-// The fix needs codegen to plumb a sized args buffer across the
-// boundary so the worker has a self-contained copy. Until that
-// lands, callers should treat the async API as "must Await before
-// the launching function returns" and not store handles long-term.
-//
-// (Also note: the ESP save/restore brackets a `new` and a
-// `std::async` -- both are C++ calls that should not need stack-
-// pointer rescue, but the asm is preserved for now because removing
-// it interacts with the va_list ABI in ways that warrant a focused
-// look in the same future codegen PR.)
-template<typename T>
-int _bbAsyncCallFunctionPointer(BBFunction<T> functionPtr, va_list args) {
-	int32_t StackPointer;
+int _bbReference(int vPtr);
+int _bbRelease(int vPtr, const char *s);
 
-	__asm { // Store Stack Pointer
-		mov StackPointer, esp;
+static int _bbReferenceIfTracked(int vPtr) {
+	if (vPtr == 0) {
+		return 0;
 	}
+	auto it = reference_map.find(vPtr);
+	if (it == reference_map.end()) {
+		return 0;
+	}
+	++(it->second.count);
+	return vPtr;
+}
+
+template<typename T>
+struct BBAsyncCallState {
+	std::future<T> future;
+	int retainedPayload;
+	const char *retainedType;
+};
+
+// Async and AsyncThen expose exactly one pointer-sized payload slot
+// in basic_link(). The runtime ABI carries that slot in a va_list-typed
+// parameter, but on this surface the value itself is the payload; do
+// not va_arg() through it or the worker will read object memory as a
+// caller-frame argument cursor.
+template<typename T>
+int _bbAsyncCallFunctionPointerOwned(BBFunction<T> functionPtr, va_list args, bool retainPayload) {
+	int payload = reinterpret_cast<int>(args);
+	va_end(args);
+	int retainedPayload = retainPayload ? _bbReferenceIfTracked(payload) : 0;
+	va_list ownedArgs = reinterpret_cast<va_list>(payload);
 
 	// Create a std::future<int> and store it in a dynamically allocated object
-	std::future<T>* futurePtr = new std::future<T>(std::async(std::launch::async, functionPtr, args));
-
-	__asm { // Restore Stack Pointer
-		mov esp, StackPointer;
-	}
-
-	va_end(args);
+	BBAsyncCallState<T>* state = new BBAsyncCallState<T>{
+		std::async(std::launch::async, functionPtr, ownedArgs),
+		retainedPayload,
+		retainPayload ? "BBCustom" : nullptr
+	};
 
 	// Return the pointer as intptr_t
-	return reinterpret_cast<int>(futurePtr);
+	return reinterpret_cast<int>(state);
+}
+
+template<typename T>
+int _bbAsyncCallFunctionPointer(BBFunction<T> functionPtr, va_list args) {
+	return _bbAsyncCallFunctionPointerOwned(functionPtr, args, true);
 }
 
 template<typename T>
 T _bbAwaitAsyncCall(int threadPtr) {
-	std::future<T>* futurePtr = reinterpret_cast<std::future<T>*>(threadPtr);
+	BBAsyncCallState<T>* state = reinterpret_cast<BBAsyncCallState<T>*>(threadPtr);
 	// Guard against null / sentinel handle. Doesn't prevent the
 	// double-Await UAF (caller still holds the original int value
 	// after we delete) but at least bails on the obvious mis-use.
-	if (futurePtr == nullptr) {
+	if (state == nullptr) {
 		return T();
 	}
-	T result = futurePtr->get();
-	delete futurePtr;
+	T result = state->future.get();
+	if (state->retainedPayload != 0) {
+		_bbRelease(state->retainedPayload, state->retainedType);
+	}
+	delete state;
 	return result;
 }
 
 template<typename T>
 int _bbPollAsyncCall(int threadPtr) {
-	std::future<T>* futurePtr = reinterpret_cast<std::future<T>*>(threadPtr);
-	if (futurePtr == nullptr) {
+	BBAsyncCallState<T>* state = reinterpret_cast<BBAsyncCallState<T>*>(threadPtr);
+	if (state == nullptr) {
 		return 1;  // null handle: "ready" so the caller stops polling
 	}
-	return futurePtr->wait_for(std::chrono::milliseconds(1)) == std::future_status::ready;
+	return state->future.wait_for(std::chrono::milliseconds(1)) == std::future_status::ready;
 }
 
 int _bbAsyncThenCall(va_list threadPtr, BBFunction<int> functionPtr) {
-	return _bbAsyncCallFunctionPointer(functionPtr, threadPtr);
+	return _bbAsyncCallFunctionPointerOwned(functionPtr, threadPtr, false);
 }
 
 // Wrap thrown payloads in a tagged struct so `catch` doesn't

--- a/tests/FunctionPointerTest.bb
+++ b/tests/FunctionPointerTest.bb
@@ -53,6 +53,7 @@ Function thirdTestFunction@( arg.BasicDTO=Null )
         return FunctionPtr()
     end if
 
+    delay 20
     Local var = arg\var + 1
     return new BasicDTO(var)
 End Function
@@ -66,6 +67,42 @@ Function fourthTestFunction@( threadPtr.BBThread=Null )
 
     Local var = result\var + 1
     return new BasicDTO(var)
+End Function
+
+Function launchAsyncIdentity.BBThread(dto.BasicDTO)
+    Local f_ptr.BBFunction = thirdTestFunction()
+    Return Async(f_ptr, dto)
+End Function
+
+Function launchAsyncThenIdentity.BBThread(dto.BasicDTO)
+    Local f_ptr.BBFunction = thirdTestFunction()
+    Local f_ptr_2.BBFunction = fourthTestFunction()
+    Local t_ptr.BBThread = Async(f_ptr, dto)
+    Return AsyncThen(t_ptr, f_ptr_2)
+End Function
+
+Function clobberFunctionPointerStack()
+    Local a0 = 100
+    Local a1 = 101
+    Local a2 = 102
+    Local a3 = 103
+    Local a4 = 104
+    Local a5 = 105
+    Local a6 = 106
+    Local a7 = 107
+
+    For i = 0 To 256
+        a0 = a0 + i
+        a1 = a1 + a0
+        a2 = a2 + a1
+        a3 = a3 + a2
+        a4 = a4 + a3
+        a5 = a5 + a4
+        a6 = a6 + a5
+        a7 = a7 + a6
+    Next
+
+    Assert(a7 <> 107)
 End Function
 
 Test testFunctionPointer()
@@ -154,4 +191,28 @@ Test testThen()
 
     Local result.BasicDTO = Await(t_ptr_2)
     Assert(result\var = 3)
+End Test
+
+Test testThreadPayloadOutlivesLauncher()
+    Local t1.BBThread = launchAsyncIdentity(new BasicDTO(101))
+    clobberFunctionPointerStack()
+    Local r1.BasicDTO = Await(t1)
+    Assert(r1\var = 102)
+
+    Local t2.BBThread = launchAsyncIdentity(new BasicDTO(202))
+    clobberFunctionPointerStack()
+    Local r2.BasicDTO = Await(t2)
+    Assert(r2\var = 203)
+End Test
+
+Test testThenPayloadOutlivesLauncher()
+    Local t1.BBThread = launchAsyncThenIdentity(new BasicDTO(11))
+    clobberFunctionPointerStack()
+    Local r1.BasicDTO = Await(t1)
+    Assert(r1\var = 13)
+
+    Local t2.BBThread = launchAsyncThenIdentity(new BasicDTO(22))
+    clobberFunctionPointerStack()
+    Local r2.BasicDTO = Await(t2)
+    Assert(r2\var = 24)
 End Test


### PR DESCRIPTION
## Non-technical summary

Async function-pointer calls now keep their tracked object payload alive after the launcher returns. This makes `Async(...)` and `AsyncThen(...)` safer for the intended DTO-style function-pointer workflow instead of depending on the launching frame's lifetime.

## Technical summary

Implementation plan:
- Replace the known unsafe async function-pointer path in `src/blitzrc/bbruntime/basic.cpp` with an internal async call state that owns the future handle and any retained payload metadata.
- Copy the function-pointer payload value before launching the worker. During implementation, validation showed this ABI carries the single pointer-sized payload directly in a `va_list`-typed parameter; dereferencing it with `va_arg` corrupts dispatch. The final code copies the value itself and documents that ABI detail.
- Retain only payloads already tracked by BlitzForge's reference map, so object DTOs survive until `Await` while arbitrary untracked `BBPointer` values are not accidentally registered and destroyed as custom objects.
- Keep `AsyncThen` from retaining the input `BBThread` handle as a custom object; it copies the handle value but leaves ownership with the await chain.
- Add focused regression coverage in `tests/FunctionPointerTest.bb` for `Async` and `AsyncThen` handles returned from launcher functions, with a delayed worker and intervening stack clobber.

No public syntax changes and no intended breaking changes. Internally, `BBThread` handles returned by this runtime path now point to `BBAsyncCallState<T>` instead of a bare `std::future<T>`; `Await` and `Poll` are updated together.

## Acceptance criteria + test results

- [x] `Async(BBFunction, BBPointer)` no longer depends on a caller-frame argument cursor after launch. Covered by `testThreadPayloadOutlivesLauncher`.
- [x] `AsyncThen(BBThread, BBFunction)` follows the same copied-payload discipline without retaining the upstream thread handle as a custom object. Covered by `testThenPayloadOutlivesLauncher`.
- [x] Existing async function-pointer behavior still works. Covered by `testThread`, `testThreadPoll`, and `testThen`.
- [x] The old known-bug comment is removed and replaced with the corrected ABI note.
- [x] Windows verification passed: incremental MSBuild `Build`, targeted `bin\\blitzcc.exe -t tests\\FunctionPointerTest.bb`, full `test.bat`, and `git diff --check`.

## Trade-offs and deferred follow-ups

- Payload retention is intentionally conservative: only already-tracked payloads are retained. This avoids treating arbitrary `BBPointer` values as `BBCustom` objects.
- This does not make the whole Blitz runtime allocator thread-safe. The regression tests avoid concurrent allocator stress and focus on the async payload ownership contract.
- A future cleanup could introduce a named non-template async handle type if more async result types are added; this increment keeps the existing `int` handle ABI intact.
