### PR TITLE
Fix Replace() hang on empty search string + first string test suite

### DIFF
--- a/docs/notes/fix-replace-empty-from-hang.md
+++ b/docs/notes/fix-replace-empty-from-hang.md
@@ -1,0 +1,98 @@
+# Working note — Fix `Replace()` hang on empty search string + first string test suite
+
+Branch: `fix/replace-empty-from-hang`
+Type: Bug / Reliability
+Status: working note (delete-or-keep at reviewer's discretion; this is grounding intent, not shipped docs)
+
+## Goal (restated)
+
+`Replace(s$, from$, to$)` enters an infinite loop — the runtime hangs — whenever
+`from$` is the empty string. Because `Replace` is one of the most-used string
+commands in any Blitz program, a single accidental empty search string turns into
+an unrecoverable hang with no error. Close that hang with a minimal, legacy-safe
+guard, and pin the behavior (plus the surrounding string-command boundary contract)
+with the suite's first dedicated string tests.
+
+## Root cause
+
+`src/blitzrc/bbruntime/bbstring.cpp:26-33`:
+
+```cpp
+BBStr *bbReplace( BBStr *s,BBStr *from,BBStr *to ){
+    int n=0,from_sz=(int)from->size(),to_sz=(int)to->size();
+    while( n<((int)s->size()) && (n=s->find( *from,n ))!=string::npos){
+        s->replace( n,from_sz,*to );
+        n+=to_sz;
+    }
+    delete from;delete to;return s;
+}
+```
+
+When `from` is empty, `std::string::find("", n)` returns `n` for any `n <= size()`
+(never `npos`), so the loop body always runs:
+
+- empty `to` → `to_sz == 0`, `n` never advances → infinite loop.
+- non-empty `to` → each iteration inserts `to` and grows `s` by `to_sz`, and
+  advances `n` by `to_sz`; the gap `size() - n` stays constant → infinite loop.
+
+Either way it hangs. Since the current behavior is a hang, **no working legacy
+program can depend on it**, so any terminating behavior is strictly safer.
+
+## Chosen semantic
+
+`Replace(s, "", to)` returns `s` unchanged. This matches the least-surprise
+contract used across Blitz dialects and other languages (an empty search string
+has no occurrence to replace) and is the minimal change that removes the hang
+while preserving every well-formed (non-empty `from`) result byte-for-byte.
+
+## Approach (in order)
+
+1. **Pin first** — add `tests/StringTest.bb` (`Strict` + `EnableGC`) asserting the
+   intended behavior for the string commands, including:
+   - `Replace` normal case, no-match case, and the empty-`from` case (must return
+     the original string and, critically, must *terminate*).
+   - `Left` / `Right` / `Mid` boundary clamping (offset/count past end, `Mid`
+     count = -1 meaning "to end"), proving they return defined strings.
+   - `Instr` found / not-found / `from` past end.
+   - `Trim`, `Upper`, `Lower`, `LSet`, `RSet`, `Chr`, `Asc` (incl. `Asc("") = -1`),
+     `Len`, `Hex`, `Bin` documented contracts.
+2. **Fix** — in `bbReplace`, early-return `s` unchanged when `from` is empty,
+   deleting `from`/`to` to preserve the function's ownership contract.
+3. **Verify** — `test.bat` green (the new suite + all 16 existing suites).
+
+## Files / interfaces touched
+
+- `src/blitzrc/bbruntime/bbstring.cpp` — `bbReplace` only (one guard).
+- `tests/StringTest.bb` — new.
+- `docs/notes/fix-replace-empty-from-hang.md` — this note.
+
+No public-API, ABI, or `.decls` change. No other string function is modified —
+`bbMid`/`bbLeft`/`bbRight`/`bbLSet`/`bbRSet` were verified already clamped, so the
+tests pin existing-safe behavior rather than changing it.
+
+## Migration / rollback
+
+No migration. Rollback = revert the commit; the only behavior change is that a
+previously-hanging input now returns a value, so revert risk is nil.
+
+## Sequencing
+
+Test file and fix land together in the diff. The empty-`from` test would hang
+against the unpatched runtime, so it is only meaningful alongside the fix — both
+ship in the same PR.
+
+## Trade-offs considered and rejected
+
+- **Bundling math (`bbmath.cpp`) coverage** (recon pitch 2): rejected — no confirmed
+  defect there; pure coverage would balloon a focused reliability fix into a broad
+  test sweep. Deferred as its own future increment.
+- **"Insert `to` between every char" semantic for empty `from`**: rejected — surprising,
+  not legacy behavior, and still requires a termination guard anyway.
+- **Documenting modern language features** (recon pitch 3): worthy, `M` effort,
+  editorial; deferred.
+
+## Deferred follow-ups
+
+- `tests/MathTest`-style coverage for `bbmath.cpp` (Sqrt(-1), Log(0), trig domain).
+- Broader string edge audit (multi-byte / locale behavior of `toupper`/`isgraph`).
+- Modern-feature reference pages under `help/language/` (pitch 3).

--- a/src/blitzrc/bbruntime/bbstring.cpp
+++ b/src/blitzrc/bbruntime/bbstring.cpp
@@ -25,6 +25,11 @@ BBStr *bbRight( BBStr *s,int n ){
 
 BBStr *bbReplace( BBStr *s,BBStr *from,BBStr *to ){
 	int n=0,from_sz=(int)from->size(),to_sz=(int)to->size();
+	// An empty search string has no occurrence to replace. std::string::find("",n)
+	// returns n (never npos), so without this guard the loop below never terminates:
+	// with an empty `to` n never advances, and with a non-empty `to` the string grows
+	// in lockstep with n. Return s unchanged, matching least-surprise Blitz semantics.
+	if( from_sz==0 ){ delete from;delete to;return s; }
 	while( n<((int)s->size()) && (n=s->find( *from,n ))!=string::npos){
 		s->replace( n,from_sz,*to );
 		n+=to_sz;

--- a/tests/StringTest.bb
+++ b/tests/StringTest.bb
@@ -1,0 +1,157 @@
+Strict
+EnableGC
+
+; Acceptance suite for the string standard library.
+; Each block proves one documented contract with exact literal expectations.
+; No block performs an operation documented to potentially hang.
+
+; --- Replace: empty `from` must terminate and return s unchanged (criterion 1) ---
+
+Test ReplaceEmptyFromTest()
+    Assert( Replace("hello", "", "x") = "hello" )
+    Assert( Replace("hello", "", "") = "hello" )
+    ; Empty source string with empty from must also terminate and return unchanged.
+    Assert( Replace("", "", "x") = "" )
+End Test
+
+; --- Replace: normal match / no match (criterion 2) ---
+
+Test ReplaceMatchTest()
+    ; Every occurrence replaced.
+    Assert( Replace("aaa", "a", "b") = "bbb" )
+    Assert( Replace("hello world", "o", "0") = "hell0 w0rld" )
+    Assert( Replace("ababab", "ab", "X") = "XXX" )
+End Test
+
+Test ReplaceNoMatchTest()
+    Assert( Replace("hello", "z", "Q") = "hello" )
+    Assert( Replace("hello", "xyz", "Q") = "hello" )
+End Test
+
+; --- Left / Right / Mid boundaries (criterion 3) ---
+
+Test LeftBoundaryTest()
+    Assert( Left("abc", 2) = "ab" )
+    Assert( Left("abc", 3) = "abc" )
+    ; n past end returns whole string.
+    Assert( Left("abc", 10) = "abc" )
+    Assert( Left("abc", 0) = "" )
+End Test
+
+Test RightBoundaryTest()
+    Assert( Right("abc", 2) = "bc" )
+    Assert( Right("abc", 3) = "abc" )
+    ; n past end returns whole string.
+    Assert( Right("abc", 10) = "abc" )
+    Assert( Right("abc", 0) = "" )
+End Test
+
+Test MidBoundaryTest()
+    ; Default count (-1) means "to end of string".
+    Assert( Mid("hello", 2) = "ello" )
+    Assert( Mid("hello", 1) = "hello" )
+    ; Explicit count.
+    Assert( Mid("hello", 2, 3) = "ell" )
+    ; start past the end returns "".
+    Assert( Mid("hi", 10, 5) = "" )
+    ; count past end clamps to remaining chars.
+    Assert( Mid("hello", 3, 99) = "llo" )
+End Test
+
+; --- Instr: found / not-found / from past end (criterion 4) ---
+
+Test InstrFoundTest()
+    Assert( Instr("hello", "l") = 3 )
+    Assert( Instr("hello", "hello") = 1 )
+    Assert( Instr("hello", "o") = 5 )
+End Test
+
+Test InstrNotFoundTest()
+    Assert( Instr("hello", "z") = 0 )
+End Test
+
+Test InstrFromTest()
+    ; from skips earlier matches.
+    Assert( Instr("hello", "l", 4) = 4 )
+    ; from past end returns 0.
+    Assert( Instr("hello", "o", 99) = 0 )
+End Test
+
+; --- Trim (criterion 5) ---
+
+Test TrimTest()
+    Assert( Trim("  hello  ") = "hello" )
+    Assert( Trim("hello") = "hello" )
+    ; Tabs and other non-graphical chars are whitespace.
+    Assert( Trim( Chr(9) + "hello" + Chr(9) ) = "hello" )
+    ; whitespace-only string trims to empty.
+    Assert( Trim("    ") = "" )
+End Test
+
+; --- Upper / Lower (criterion 6) ---
+
+Test UpperLowerTest()
+    Assert( Upper("Hello World") = "HELLO WORLD" )
+    Assert( Lower("Hello World") = "hello world" )
+    ; Non-alpha chars are left untouched.
+    Assert( Upper("abc123") = "ABC123" )
+    Assert( Lower("ABC123") = "abc123" )
+End Test
+
+; --- LSet / RSet truncate + pad (criterion 6) ---
+
+Test LSetTest()
+    ; pad shorter with trailing spaces.
+    Assert( LSet("ab", 5) = "ab   " )
+    ; truncate longer.
+    Assert( LSet("abcdef", 3) = "abc" )
+    ; exact width unchanged.
+    Assert( LSet("abc", 3) = "abc" )
+End Test
+
+Test RSetTest()
+    ; pad shorter with leading spaces.
+    Assert( RSet("ab", 5) = "   ab" )
+    ; truncate longer, keeping rightmost.
+    Assert( RSet("abcdef", 3) = "def" )
+    ; exact width unchanged.
+    Assert( RSet("abc", 3) = "abc" )
+End Test
+
+; --- Chr / Asc, including Asc("") = -1 (criterion 6) ---
+
+Test ChrAscTest()
+    Assert( Chr(65) = "A" )
+    Assert( Asc("A") = 65 )
+    ; Asc of first char only.
+    Assert( Asc("ABC") = 65 )
+    ; round-trip.
+    Assert( Asc( Chr(97) ) = 97 )
+    ; empty string returns -1.
+    Assert( Asc("") = -1 )
+End Test
+
+; --- Len (criterion 6) ---
+
+Test LenTest()
+    Assert( Len("hello") = 5 )
+    Assert( Len("") = 0 )
+    Assert( Len(" ") = 1 )
+End Test
+
+; --- Hex (criterion 6) ---
+
+Test HexTest()
+    Assert( Hex(255) = "000000FF" )
+    Assert( Hex(0) = "00000000" )
+    Assert( Hex(16) = "00000010" )
+End Test
+
+; --- Bin (criterion 6) ---
+
+Test BinTest()
+    Assert( Len( Bin(5) ) = 32 )
+    Assert( Right( Bin(5), 4 ) = "0101" )
+    Assert( Bin(0) = "00000000000000000000000000000000" )
+    Assert( Right( Bin(1), 1 ) = "1" )
+End Test


### PR DESCRIPTION
## Non-technical summary

`Replace(s$, from$, to$)` — one of the most-used string commands in any Blitz program — would **hang the entire program forever** if the search string (`from$`) was empty. No error, no crash log: just an unrecoverable freeze. This PR makes that case return the string unchanged (the least-surprise result) and ships the test suite's first dedicated coverage of the string standard library so the contract can't silently regress again.

This advances INTENT.md's "no more silent corruption on edge cases" goal and value #5 ("tested over commented"), and is deliberately orthogonal to the recent GC/async/Strict cluster.

## Technical summary

**Root cause** (`src/blitzrc/bbruntime/bbstring.cpp`): `std::string::find("", n)` returns `n` (never `npos`) for any `n <= size()`, so the replace loop never terminated when `from` was empty — with an empty `to` the index never advanced; with a non-empty `to` the string grew in lockstep with the index. Either way: infinite loop.

**Fix:** an early guard returns `s` unchanged (deleting `from`/`to` to preserve the function's ownership contract) when the search string is empty. Every well-formed (non-empty `from`) result is byte-for-byte identical to before. Since the prior behavior was a hang, no working legacy program can depend on it — so this is drop-in-compatibility-safe (value #1).

**Tests:** new `tests/StringTest.bb` (16 `Test` blocks) — the first dedicated string-command coverage. Written from acceptance criteria by an agent that had not seen the fix, then verified against the runtime. Pins the empty-`from` `Replace` contract (must terminate) plus boundary behavior of `Left`/`Right`/`Mid`/`Instr`/`Trim`/`Upper`/`Lower`/`LSet`/`RSet`/`Chr`/`Asc`/`Len`/`Hex`/`Bin`.

No ABI / `.decls` / public-API change. Only `bbReplace` is modified; the other string functions were verified already-clamped and are pinned, not changed.

## Acceptance criteria

- [x] `Replace(s, "", "x")` and `Replace(s, "", "")` complete (no hang) and return `s` unchanged — verified: run finishes in seconds, asserts pass.
- [x] `Replace` replaces all occurrences on match; returns input unchanged on no match.
- [x] `Left`/`Right`/`Mid` past-end offsets/counts return defined strings, never crash.
- [x] `Instr` found / not-found / `from` past end behave per contract.
- [x] `Trim` strips leading/trailing whitespace incl. tabs; whitespace-only → empty.
- [x] `Upper`/`Lower`/`LSet`/`RSet`/`Chr`/`Asc` (incl. `Asc("")=-1`)/`Len`/`Hex(255)="000000FF"`/`Bin` width pinned.
- [x] `test.bat` green — new suite plus all 16 existing suites pass (exit 0). Local build: 0 errors.

## Trade-offs & deferred follow-ups

- **Scoped to strings, not math.** Recon surfaced a sibling "add `bbmath.cpp` coverage" idea, but math has no confirmed defect — bundling it would turn a focused reliability fix into a broad coverage sweep. Deferred.
- Deferred: math-function edge tests (`Sqrt(-1)`, `Log(0)`, trig domain); broader string locale/multibyte audit; modern-feature reference pages under `help/language/`.
- Working note at `docs/notes/fix-replace-empty-from-hang.md` records the grounding intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)