### PR TITLE
docs: warn that BlitzForge keyword additions are globally reserved

### DIFF
--- a/help/language/lang_ref_keywords.html
+++ b/help/language/lang_ref_keywords.html
@@ -32,7 +32,10 @@ content="text/html; charset=iso-8859-1">
 <blockquote>
   <p class="header">BlitzForge additions</p>
   <p>BlitzForge reserves these additional words for its modern language extensions.
-    See the <a href="lang_ref_modern.html">Modern Features</a> page for what each does:</p>
+    See the <a href="lang_ref_modern.html">Modern Features</a> page for what each does.
+    Note that these words are reserved in <i>all</i> programs, so legacy code that
+    used one of them (for example <i>test</i> or <i>release</i>) as a variable or
+    function name will need that identifier renamed:</p>
 </blockquote>
 <table width="90%" border="0" cellspacing="0" cellpadding="0" align="center">
   <tr>


### PR DESCRIPTION
Small follow-up to [#67](https://github.com/RydeTec/blitz-forge/pull/67) addressing the one non-blocking suggestion from review.

The Keywords page now warns that BlitzForge's added reserved words apply to **all** programs (not only `Strict` files), so legacy `.bb` code that used one of them (e.g. `test`, `release`) as an identifier must rename it. This documents the known global-reservation trap right where a user will encounter it, until the contextual-keyword fix (deferred, INTENT #1) lands.

Docs-only, one sentence. No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)