### PR TITLE
Add test coverage for the math library and numeric/string conversions

### DIFF
--- a/docs/notes/math-conversion-coverage.md
+++ b/docs/notes/math-conversion-coverage.md
@@ -1,0 +1,78 @@
+# Working note — Math library + numeric/string conversion test coverage
+
+Branch: `test/math-conversion-coverage`
+Type: Test coverage
+
+## Goal (restated)
+
+`tests/MathsTest.bb` is named for math but tests only `+ - * /` (compiler codegen).
+Every function actually in `src/blitzrc/bbruntime/bbmath.cpp` — `Sin Cos Tan ASin
+ACos ATan ATan2 Sqr Floor Ceil Exp Log Log10 Rnd Rand SeedRnd RndSeed` — has zero
+coverage, and so do the `Str`/`Int`/`Float` conversion paths (`_bbIntToStr`/itoa,
+`_bbStrToInt`/atoi, `_bbStrToFloat`/atof, `_bbFloatToStr`/ftoa). These pin two
+regression-prone, non-obvious contracts that matter for downstream reproducibility:
+- **Degree-based trig** (`bbmath.cpp:14-20`): `Sin(90)=1`, not radians. A future
+  "fix" to radians would silently break every Blitz program.
+- **Deterministic PRNG** (`bbmath.cpp:24-50`): fixed Lehmer LCG; `SeedRnd(s)` makes
+  the stream reproducible; `SeedRnd(0)` maps to state 1 (so `≡ SeedRnd(1)`);
+  `Rand(from,to)` swaps reversed args and is inclusive. rcce2 relies on seeded
+  reproducibility.
+
+Add executable `blitzcc -t` coverage that locks these contracts in.
+
+## Approach (in order)
+
+1. **Expand `tests/MathsTest.bb`** (keep the 4 arithmetic tests; add math-library
+   `Test` blocks): degree trig with epsilon tolerance (`Sin(0)=0`, `Sin(90)≈1`,
+   `Cos(0)=1`, `Cos(90)≈0`, `Tan(45)≈1`, inverse round-trips `ASin(1)≈90`,
+   `ACos(0)≈90`, `ATan(1)≈45`, `ATan2(1,1)≈45`); exact-where-exact (`Sqr(9)=3`,
+   `Floor(2.7)=2`, `Floor(-2.1)=-3`, `Ceil(2.1)=3`, `Ceil(-2.9)=-2`, `Exp(0)=1`,
+   `Log(1)=0`, `Log10(1000)≈3`); PRNG determinism.
+2. **PRNG strategy** — prefer *reproduction-based* asserts (seed, draw a sequence,
+   re-seed the same value, assert the sequence repeats) so the test is robust and
+   cross-platform; ADD a few *frozen* `Rand` literals captured from a real Windows
+   run to pin the actual algorithm (the integer LCG is bit-reproducible across
+   platforms, so frozen `Rand` values double as a cross-platform contract). Also:
+   `SeedRnd(0)` stream == `SeedRnd(1)` stream; `Rand(5,5)=5`; `Rand(6,1)` ∈ [1,6]
+   (swap path); `Rnd(0,1)` ∈ (0,1).
+3. **New `tests/ConversionTest.bb`** — `Str(int)`, `Int(str)` (`Int("42")=42`,
+   `Int("12abc")=12`, `Int("")=0`), `Float(str)` (`Float("3.14")≈3.14`), and a few
+   `Str(float)` values **captured empirically** from ftoa (not guessed).
+4. Float comparisons use an `Abs(a-b) < eps` helper (`Assert` takes a bool; exact
+   float equality is fragile). Integer/`Sqr(9)`/`Floor`/`Ceil` asserted exactly.
+
+## Files touched
+
+- `tests/MathsTest.bb` (expand)
+- `tests/ConversionTest.bb` (new)
+- `docs/notes/math-conversion-coverage.md` (this note)
+
+Test-only. No `src/` changes. If a test surfaces a real bug, file it separately
+(do not fix here).
+
+## Acceptance criteria (Artifact B = the tests, validated by running them)
+
+- `MathsTest.bb` covers all 17 `bbmath.cpp` functions; `ConversionTest.bb` covers
+  `Str`/`Int`/`Float`. Both run under `blitzcc -t` and pass on Windows (`test.bat`
+  exit 0).
+- A dedicated block asserts the **degree-trig** contract and another asserts
+  **`SeedRnd` reproducibility** (+ the `SeedRnd(0)==SeedRnd(1)` remap).
+- Every pinned literal/float expectation is captured from a real run, not guessed.
+- The corpus sweep and all other suites remain green.
+
+## Trade-offs / rejected
+
+- **Rejected: rewrite MathsTest from scratch** — keep the existing arithmetic tests
+  (no coverage lost), just add to them.
+- **Rejected this iteration: the `seTranslator` missing-`break` bug** (recon agent 2).
+  Real, confirmed, tiny — but asserting an SEH panic message from inside the `-t`
+  harness is awkward (a panic exits the process). Deferred as the top Bug candidate;
+  its verification needs a manual crash-repro rather than a Test block.
+- Frozen-literal RNG values risk locking in a buggy stream — mitigated by also using
+  reproduction-based asserts and reviewing values against the documented LCG.
+
+## Deferred follow-ups
+
+- `seTranslator` missing-`break` fix (Bug/Reliability), with a manual-repro
+  verification approach.
+- Banks / type-list / stream edge-case coverage.

--- a/tests/ConversionTest.bb
+++ b/tests/ConversionTest.bb
@@ -1,0 +1,46 @@
+Strict
+EnableGC
+
+; Numeric <-> string conversion contracts.
+; Str(int)  -> itoa, Int(str) -> atoi, Float(str) -> atof, Str(float) -> ftoa.
+; The atoi/atof contracts (partial parse, empty -> 0) and ftoa's formatting
+; (trailing ".0", 6 significant digits) govern every number a Blitz program
+; reads or prints, and were previously untested.
+
+Test testIntToStr()
+    Assert( Str(3) = "3" )
+    Assert( Str(0) = "0" )
+    Assert( Str(-42) = "-42" )
+    Assert( Str(2147483647) = "2147483647" )
+End Test
+
+Test testStrToInt()
+    Assert( Int("42") = 42 )
+    Assert( Int("-7") = -7 )
+    Assert( Int("0") = 0 )
+    ; atoi parses the leading numeric prefix and stops at the first non-digit.
+    Assert( Int("12abc") = 12 )
+    ; non-numeric / empty parse to 0.
+    Assert( Int("abc") = 0 )
+    Assert( Int("") = 0 )
+End Test
+
+Test testStrToFloat()
+    ; Float(str) is atof; compare within an epsilon.
+    Local d# = Float("3.14") - 3.14
+    If d < 0.0 Then d = -d
+    Assert( d < 0.0001 )
+    Assert( Float("0") = 0.0 )
+    Assert( Float("10") = 10.0 )
+    Assert( Float("") = 0.0 )
+End Test
+
+; Str(float) formatting (ftoa). Values captured from the Windows build; note the
+; trailing ".0" on whole-valued floats (Str(1.0) = "1.0", not "1").
+Test testFloatToStr()
+    Assert( Str(1.5) = "1.5" )
+    Assert( Str(0.5) = "0.5" )
+    Assert( Str(1.0) = "1.0" )
+    Assert( Str(100.0) = "100.0" )
+    Assert( Str(3.14159) = "3.14159" )
+End Test

--- a/tests/MathsTest.bb
+++ b/tests/MathsTest.bb
@@ -1,6 +1,8 @@
 Strict
 EnableGC
 
+; --- Arithmetic operators (compiler codegen) ---
+
 Test AdditionTest()
     Assert( 1 + 1 = 2 )
 End Test
@@ -17,3 +19,112 @@ Test DivisionTest()
     Assert( 4 / 2 = 2 )
 End Test
 
+; --- Math library (bbmath.cpp) ---
+; Float helper: Assert takes a bool, and exact float equality is fragile, so
+; compare within a small epsilon. Avoids Abs() to keep the type unambiguous.
+
+Function FloatClose%( a#, b# )
+    Local d# = a - b
+    If d < 0.0 Then d = -d
+    Return ( d < 0.0001 )
+End Function
+
+; Trig is DEGREE-based in Blitz (Sin(90)=1, not Sin(pi/2)). This is a deliberate,
+; non-obvious contract; pin it so a future "fix" to radians is caught.
+Test testDegreeTrig()
+    Assert( FloatClose( Sin(0.0), 0.0 ) )
+    Assert( FloatClose( Sin(90.0), 1.0 ) )
+    Assert( FloatClose( Sin(30.0), 0.5 ) )
+    Assert( FloatClose( Cos(0.0), 1.0 ) )
+    Assert( FloatClose( Cos(90.0), 0.0 ) )
+    Assert( FloatClose( Tan(45.0), 1.0 ) )
+End Test
+
+Test testInverseTrig()
+    Assert( FloatClose( ASin(1.0), 90.0 ) )
+    Assert( FloatClose( ACos(0.0), 90.0 ) )
+    Assert( FloatClose( ATan(1.0), 45.0 ) )
+    Assert( FloatClose( ATan2(1.0, 1.0), 45.0 ) )
+End Test
+
+Test testSqrFloorCeil()
+    Assert( FloatClose( Sqr(9.0), 3.0 ) )
+    Assert( FloatClose( Sqr(2.0), 1.41421 ) )
+    Assert( Floor(2.7) = 2 )
+    Assert( Floor(-2.1) = -3 )
+    Assert( Ceil(2.1) = 3 )
+    Assert( Ceil(-2.9) = -2 )
+End Test
+
+Test testExpLog()
+    Assert( FloatClose( Exp(0.0), 1.0 ) )
+    Assert( FloatClose( Log(1.0), 0.0 ) )
+    Assert( FloatClose( Log10(1000.0), 3.0 ) )
+End Test
+
+; --- Deterministic PRNG (bbmath.cpp Lehmer LCG) ---
+
+; Seeding makes the stream reproducible. rcce2 and seeded games depend on this.
+Test testSeedRndReproducible()
+    SeedRnd( 1234 )
+    Local a1 = Rand( 1, 1000000 )
+    Local a2 = Rand( 1, 1000000 )
+    Local a3 = Rand( 1, 1000000 )
+    SeedRnd( 1234 )
+    Assert( Rand( 1, 1000000 ) = a1 )
+    Assert( Rand( 1, 1000000 ) = a2 )
+    Assert( Rand( 1, 1000000 ) = a3 )
+End Test
+
+; Frozen literals captured from the Windows build. The integer LCG is
+; bit-reproducible across platforms, so these also serve as a cross-platform
+; contract: any algorithm/seed drift changes them.
+Test testRandKnownSequence()
+    SeedRnd( 1234 )
+    Assert( Rand( 1, 1000000 ) = 911355 )
+    Assert( Rand( 1, 1000000 ) = 624215 )
+    Assert( Rand( 1, 1000000 ) = 759072 )
+End Test
+
+; SeedRnd masks to 0x7fffffff and maps seed 0 to state 1, so SeedRnd(0) and
+; SeedRnd(1) produce the same stream.
+Test testSeedRndZeroMapsToOne()
+    SeedRnd( 0 )
+    Local a = Rand( 1, 1000000 )
+    SeedRnd( 1 )
+    Assert( Rand( 1, 1000000 ) = a )
+End Test
+
+; Rand is inclusive on both ends and swaps reversed arguments.
+Test testRandRangeAndSwap()
+    Assert( Rand( 5, 5 ) = 5 )
+    SeedRnd( 42 )
+    Local i, ok = True
+    For i = 1 To 500
+        Local r = Rand( 6, 1 )   ; reversed args -> normalized to [1,6]
+        If r < 1 Or r > 6 Then ok = False
+    Next
+    Assert( ok )
+End Test
+
+; Rnd returns a float strictly within its range; Rnd(0,1) in (0,1).
+Test testRndRange()
+    SeedRnd( 99 )
+    Local i, ok = True
+    For i = 1 To 500
+        Local r# = Rnd( 0.0, 1.0 )
+        If r# <= 0.0 Or r# >= 1.0 Then ok = False
+    Next
+    Assert( ok )
+End Test
+
+; RndSeed reports the current generator state; after the same seed + draws it is
+; reproducible.
+Test testRndSeedState()
+    SeedRnd( 7777 )
+    Rand( 1, 100 ) : Rand( 1, 100 )
+    Local s1 = RndSeed()
+    SeedRnd( 7777 )
+    Rand( 1, 100 ) : Rand( 1, 100 )
+    Assert( RndSeed() = s1 )
+End Test


### PR DESCRIPTION
## Non-technical summary

`tests/MathsTest.bb` is *named* for math but only tested `+ - * /`. Every function in the math library — trig, square root, floor/ceil, logs, and the random-number generator — had **zero** automated coverage, as did number↔string conversion. That left two subtle, breakage-prone behaviors unguarded: Blitz trig works in **degrees** (`Sin(90)=1`, not radians), and the RNG is **deterministic** (seed once, get the same sequence — which games and rcce2 rely on for reproducible levels/replays). A future refactor could silently break either with CI staying green. This PR pins all of it with executable tests.

## Technical summary

- **`tests/MathsTest.bb` (expanded)** — keeps the 4 arithmetic tests; adds coverage of every `bbmath.cpp` function:
  - Degree-based trig (`Sin`/`Cos`/`Tan`/`ASin`/`ACos`/`ATan`/`ATan2`) and `Sqr`/`Floor`/`Ceil`/`Exp`/`Log`/`Log10`, via an epsilon `FloatClose%` helper (Assert takes a bool; exact float equality is fragile).
  - Deterministic PRNG: reproducibility after re-seeding; **frozen first-sequence literals** from a real Windows run (the integer LCG is bit-reproducible, so they double as a cross-platform contract); the `SeedRnd(0)==SeedRnd(1)` state remap; `Rand` inclusivity + reversed-arg swap; `Rnd(0,1)` range; `RndSeed()` state round-trip.
- **`tests/ConversionTest.bb` (new)** — `Str(int)`/itoa, `Int(str)`/atoi (partial-prefix parse, empty→0), `Float(str)`/atof, and `Str(float)`/ftoa formatting (incl. the trailing `.0` on whole-valued floats). All expected values captured empirically.

**Test-only — no `src/` changes.** Counters the loop's recent themes (GC/async/Throw/docs/CI) by filling the largest genuinely-empty stdlib coverage hole.

## Acceptance criteria + results

- [x] All 17 `bbmath.cpp` functions covered in `MathsTest.bb`; `Str`/`Int`/`Float` covered in `ConversionTest.bb`.
- [x] Dedicated blocks assert the **degree-trig** contract and **`SeedRnd` reproducibility** (+ the `SeedRnd(0)==SeedRnd(1)` remap).
- [x] Every pinned literal/float value captured from a real run, not guessed.
- [x] Both files pass under `blitzcc -t`; full `test.bat` exits 0; corpus sweep unaffected (new files live in `tests/`, not the corpus dirs).

## Trade-offs, deferred follow-ups

- **Deferred (top Bug candidate): the `seTranslator` missing-`break` fix** (`bbruntime_dll.cpp:59-66`) — a confirmed switch fall-through that mislabels SEH crash diagnostics. Real and tiny, but asserting a panic message from inside the `-t` harness is awkward (a panic exits the process), so it needs a manual crash-repro verification rather than a Test block; kept separate.
- If a test had surfaced a real bug it would be filed separately; none did — these pin current correct behavior.
- Deferred: banks / type-list / stream edge-case coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)