### PR TITLE
test: pin Rnd float-path determinism + annotate ftoa formatting contract

### DIFF
--- a/tests/ConversionTest.bb
+++ b/tests/ConversionTest.bb
@@ -36,7 +36,9 @@ Test testStrToFloat()
 End Test
 
 ; Str(float) formatting (ftoa). Values captured from the Windows build; note the
-; trailing ".0" on whole-valued floats (Str(1.0) = "1.0", not "1").
+; trailing ".0" on whole-valued floats (Str(1.0) = "1.0", not "1"). This pins the
+; Windows ftoa formatting contract specifically; if/when the macOS runtime executes
+; tests, float-string formatting may need a separate annotation if it diverges.
 Test testFloatToStr()
     Assert( Str(1.5) = "1.5" )
     Assert( Str(0.5) = "0.5" )

--- a/tests/MathsTest.bb
+++ b/tests/MathsTest.bb
@@ -118,6 +118,18 @@ Test testRndRange()
     Assert( ok )
 End Test
 
+; Pin Rnd's float path determinism directly (not just transitively via Rand):
+; the same seed must reproduce the same float draws. Exact float equality is
+; valid here because it's bit-identical operations from an identical state.
+Test testRndReproducible()
+    SeedRnd( 314 )
+    Local b1# = Rnd( 0.0, 1.0 )
+    Local b2# = Rnd( -5.0, 5.0 )
+    SeedRnd( 314 )
+    Assert( Rnd( 0.0, 1.0 ) = b1# )
+    Assert( Rnd( -5.0, 5.0 ) = b2# )
+End Test
+
 ; RndSeed reports the current generator state; after the same seed + draws it is
 ; reproducible.
 Test testRndSeedState()


### PR DESCRIPTION
Follow-up to [#71](https://github.com/RydeTec/blitz-forge/pull/71) applying the two non-blocking review suggestions:

- **`testRndReproducible`** — pins `Rnd()`'s float-path determinism directly (re-seed reproduces the same float draws), where before it was only covered transitively via `Rand`. Exact float equality is valid here: identical operations from an identical seeded state produce bit-identical results.
- **`testFloatToStr` annotation** — notes that the block pins the *Windows* ftoa formatting contract, flagging it for separate handling if a future macOS runtime diverges on float-string formatting.

Test-only. Verified both suites pass under `blitzcc -t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)