### PR TITLE
Bounds-check the BBList API: bad indices fail cleanly instead of via UB

### DIFF
--- a/docs/notes/bblist-bounds-checking.md
+++ b/docs/notes/bblist-bounds-checking.md
@@ -1,0 +1,82 @@
+# Working note — Bounds-check the BBList runtime API
+
+Branch: `fix/bblist-bounds-checking`
+Type: Bug / Reliability
+
+## Goal (restated)
+
+The BBList API (`_bbVector*` in `src/blitzrc/bbruntime/basic.cpp`, exposed as
+`ListAt`/`ListInsert`/`ListRemove`/`ListReplace`/`ListFirst`/`ListLast`) does zero
+index/emptiness validation on caller-supplied indices. From ordinary Blitz code:
+- `ListInsert`/`ListRemove`/`ListReplace` compute `begin()+idx` with no range check
+  → invalid iterator → **undefined behaviour / heap corruption**.
+- `ListFirst`/`ListLast` call `front()`/`back()` on a possibly-empty vector → UB.
+- `ListAt` calls `vec.at(idx)`, whose `std::out_of_range` escapes to the top-level
+  `bbruntime_run` catch and **terminates the whole program** with an STL string,
+  not a Blitz RuntimeError — and with no release-mode soft-recovery.
+
+Every other stdlib module (bank, stream, file) funnels bad input through the
+established `debug ? RTEX(msg) : errorLog.push_back(prefix+msg); return false`
+idiom (see `bbbank.cpp` `debugBank`). BBList — a modern BlitzForge API that rcce2
+leans on — is the lone exception. This contradicts INTENT #6 ("Trust the runtime")
+and the "bounds checks … always worth doing" goal.
+
+## Approach (in order)
+
+1. Add two inline guards in `basic.cpp` mirroring `debugBank`:
+   - `listIndexOk(vec, idx, who)` — rejects `idx < 0 || idx >= size()`.
+   - `listNotEmpty(vec, who)` — rejects `empty()`.
+   Each: `debug ? RTEX(...) : errorLog.push_back(who+": ...")`; returns bool.
+2. Apply:
+   - `_bbVectorAt`: `if(!listIndexOk(v,idx,"ListAt")) return 0;` then `(*v)[idx]`
+     (drop the throwing `at()`).
+   - `_bbVectorBack`/`_bbVectorFirst`: `if(!listNotEmpty(...)) return 0;`.
+   - `_bbVectorRemove`/`_bbVectorReplace`: `if(!listIndexOk(...)) return;` at top
+     (before the release/erase), so internal valid-index calls are unchanged.
+   - `_bbVectorInsert`: allow the append position — reject only `idx<0 || idx>size()`
+     (inline, since `listIndexOk` rejects `idx==size`).
+3. Add bounds/empty `Test` blocks to `tests/ListTest.bb`.
+
+## Why this is safe / behavior
+
+- In `-t` mode `debug` is false (only `-d` sets it; `debug` == "debugger attached"),
+  so bad-index ops take the `errorLog` path: **no-op + safe default, program
+  continues**. That is what the new tests assert. In `-d` debug mode they raise a
+  clean Blitz RuntimeError instead of UB.
+- Happy-path behaviour is byte-identical (guards only add a leading check).
+- The API is BlitzForge-specific → no legacy-Blitz3D compat risk.
+- `errorLog` non-empty does not fail a test (pass/fail is Assert-driven), so the
+  soft-fail tests pass.
+
+## Files touched
+
+- `src/blitzrc/bbruntime/basic.cpp` — two guards + 6 call sites.
+- `tests/ListTest.bb` — bounds/empty coverage.
+- `docs/notes/bblist-bounds-checking.md` — this note.
+
+## Acceptance criteria (Artifact B)
+
+- `ListAt`/`ListRemove`/`ListReplace` with `idx<0` or `idx>=ListSize`, and
+  `ListFirst`/`ListLast` on an empty list, no longer crash: in `-t` they no-op /
+  return 0, `ListSize` is unchanged, and a subsequent `Assert(True)` still runs
+  (proving the process did not die — the pre-fix `ListAt` out-of-range would abort
+  the whole run).
+- `ListInsert` accepts `idx == ListSize` (append) and rejects `idx > ListSize`.
+- All existing `ListTest.bb` happy-path blocks still pass unmodified.
+- Full `test.bat` green; corpus sweep unaffected.
+
+## Trade-offs / rejected
+
+- **Negative-index "count from end"** semantics — that's a feature, not a fix. Out.
+- **`_bbVectorClear` shadowed-`idx` / arg-count mismatch** (`basic.cpp:882`) — the
+  rtSym declares one arg but the C fn takes two; the inner `for` shadows the unused
+  param. Harmless, pre-existing; flagged, not fixed here.
+- Rejected this iteration: the confirmed `seTranslator` missing-`break` fix
+  (`bbruntime_dll.cpp`) and the compiler-diagnostic snippet UX — both good, lower
+  impact than a reachable memory-safety defect; deferred (seTranslator verification
+  path is now known: `-t` prints `Error: <msg>` to stdout).
+
+## Deferred follow-ups
+
+- `seTranslator` missing `break`s (Bug, trivial, verification path known).
+- Human-readable compiler diagnostics (source line + caret, sanitize EOF byte).

--- a/src/blitzrc/bbruntime/basic.cpp
+++ b/src/blitzrc/bbruntime/basic.cpp
@@ -834,6 +834,35 @@ int _bbNewVector() {
 	return ptr;
 }
 
+// BBList index/emptiness guards, mirroring the bank/stream debug-vs-errorLog
+// idiom (see bbbank.cpp debugBank). In debug builds a bad index raises a clean
+// Blitz RuntimeError; otherwise it is logged and the caller returns a safe
+// default / no-ops -- never undefined behaviour from begin()+idx / front() /
+// back() / at() on a user-supplied index.
+static inline bool listIndexOk( std::vector<int>* v, int idx, const char* who ) {
+	if( idx < 0 || idx >= (int)v->size() ) {
+		if( debug ) {
+			RTEX( "List index out of range" );
+		} else {
+			errorLog.push_back( std::string(who) + ": List index out of range" );
+		}
+		return false;
+	}
+	return true;
+}
+
+static inline bool listNotEmpty( std::vector<int>* v, const char* who ) {
+	if( v->empty() ) {
+		if( debug ) {
+			RTEX( "List is empty" );
+		} else {
+			errorLog.push_back( std::string(who) + ": List is empty" );
+		}
+		return false;
+	}
+	return true;
+}
+
 void _bbVectorPushBack(int aPtr, int valuePtr) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
@@ -844,12 +873,14 @@ void _bbVectorPushBack(int aPtr, int valuePtr) {
 int _bbVectorBack(int aPtr) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
+	if( !listNotEmpty( vecPtr, "ListLast" ) ) return 0;
 	return static_cast<int>(vecPtr->back());
 }
 
 int _bbVectorFirst(int aPtr) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
+	if( !listNotEmpty( vecPtr, "ListFirst" ) ) return 0;
 	return static_cast<int>(vecPtr->front());
 }
 
@@ -862,7 +893,8 @@ int _bbVectorEmpty(int aPtr) {
 int _bbVectorAt(int aPtr, int idx) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
-	return static_cast<int>(vecPtr->at(idx));
+	if( !listIndexOk( vecPtr, idx, "ListAt" ) ) return 0;
+	return static_cast<int>((*vecPtr)[idx]);
 }
 
 void _bbVectorRelease(int aPtr, int idx) {
@@ -900,6 +932,16 @@ int _bbVectorSize(int aPtr) {
 void _bbVectorInsert(int aPtr, int idx, int valuePtr) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
+	// idx == size() is a valid append position, so listIndexOk (which rejects
+	// idx == size) is too strict here; check the insert range explicitly.
+	if( idx < 0 || idx > (int)vecPtr->size() ) {
+		if( debug ) {
+			RTEX( "List index out of range" );
+		} else {
+			errorLog.push_back( std::string("ListInsert: List index out of range") );
+		}
+		return;
+	}
 	vecPtr->insert(vecPtr->begin() + idx, valuePtr);
 	_bbReference(valuePtr);
 }
@@ -907,6 +949,7 @@ void _bbVectorInsert(int aPtr, int idx, int valuePtr) {
 void _bbVectorRemove(int aPtr, int idx) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
+	if( !listIndexOk( vecPtr, idx, "ListRemove" ) ) return;
 	_bbVectorRelease(aPtr, idx);
 	vecPtr->erase(vecPtr->begin() + idx);
 }
@@ -914,6 +957,7 @@ void _bbVectorRemove(int aPtr, int idx) {
 void _bbVectorReplace(int aPtr, int idx, int valuePtr) {
 	void* arrayPtr = reinterpret_cast<void*>(aPtr);
 	std::vector<int>* vecPtr = static_cast<std::vector<int>*>(arrayPtr);
+	if( !listIndexOk( vecPtr, idx, "ListReplace" ) ) return;
 	// Ref new before releasing old. Otherwise, if valuePtr is the same pointer
 	// already at idx, _bbVectorRemove drops its refcount to 0 and frees it;
 	// _bbVectorInsert then references freed memory.

--- a/tests/ListTest.bb
+++ b/tests/ListTest.bb
@@ -134,3 +134,86 @@ Test testEmbeddedLists()
     FreeList(testArray2)
     FreeList(testArray)
 End Test
+
+; --- Bounds / emptiness guards ---
+; Out-of-range indices and empty-list accessors must NOT crash or corrupt memory.
+; Pre-fix, ListAt out of range threw std::out_of_range and killed the whole run;
+; Insert/Remove/Replace with a bad index dereferenced begin()+idx (UB); First/Last
+; on an empty list called front()/back() (UB). In test mode they now no-op / return
+; Null and the program keeps running. The trailing asserts only execute if the bad
+; calls did not abort the process -- that is the regression guard.
+
+Test testListAtOutOfRange()
+    Local list.BBList = CreateList()
+    ListAdd(list, new DTOTest())
+
+    ; Out-of-range and negative indices return Null instead of crashing.
+    Local hi.DTOTest = ListAt(list, 99)
+    Assert(hi = Null)
+    Local neg.DTOTest = ListAt(list, -1)
+    Assert(neg = Null)
+
+    ; Size is unchanged and the list is still usable.
+    Assert(ListSize(list) = 1)
+
+    FreeList(list)
+End Test
+
+Test testListFirstLastEmpty()
+    Local list.BBList = CreateList()
+    Assert(ListIsEmpty(list))
+
+    ; front()/back() on an empty vector is UB; guarded to return Null.
+    Local f.DTOTest = ListFirst(list)
+    Assert(f = Null)
+    Local l.DTOTest = ListLast(list)
+    Assert(l = Null)
+
+    ; Reached here => the empty-accessor calls did not abort the run.
+    Assert(ListSize(list) = 0)
+
+    FreeList(list)
+End Test
+
+Test testListRemoveReplaceOutOfRange()
+    Local list.BBList = CreateList()
+    Local a.DTOTest = new DTOTest()
+    a\val = 7
+    ListAdd(list, a)
+
+    ; Out-of-range remove/replace are no-ops: size and contents unchanged.
+    ListRemove(list, 99)
+    ListRemove(list, -1)
+    Assert(ListSize(list) = 1)
+
+    ListReplace(list, 99, new DTOTest())
+    ListReplace(list, -1, new DTOTest())
+    Assert(ListSize(list) = 1)
+
+    Local still.DTOTest = ListAt(list, 0)
+    Assert(still\val = 7)
+
+    FreeList(list)
+End Test
+
+Test testListInsertBoundary()
+    Local list.BBList = CreateList()
+    Local a.DTOTest = new DTOTest()
+    a\val = 1
+    ListAdd(list, a)
+
+    ; idx == size is the valid append position.
+    Local b.DTOTest = new DTOTest()
+    b\val = 2
+    ListInsert(list, 1, b)
+    Assert(ListSize(list) = 2)
+    Local appended.DTOTest = ListAt(list, 1)
+    Assert(appended\val = 2)
+
+    ; idx > size and negative idx are rejected (no-op).
+    ListInsert(list, 99, new DTOTest())
+    ListInsert(list, -1, new DTOTest())
+    Assert(ListSize(list) = 2)
+
+    FreeList(list)
+End Test


### PR DESCRIPTION
## Non-technical summary

`BBList` (the modern dynamic-list type, used heavily by rcce2) trusted whatever index you handed it. Pass an out-of-range or negative index — or call `ListFirst`/`ListLast` on an empty list — and the runtime hit **undefined behaviour / heap corruption**, or in the case of `ListAt`, **killed the entire program** with an opaque C++ error. This PR adds bounds checks so bad indices fail cleanly: a clear runtime error in debug builds, a safe no-op otherwise — never memory corruption. Advances INTENT value #6 ("Trust the runtime").

## Technical summary

In `src/blitzrc/bbruntime/basic.cpp`, the `_bbVector*` functions did no validation:
- `ListInsert`/`ListRemove`/`ListReplace` → `begin()+idx` with no range check (invalid iterator → UB).
- `ListFirst`/`ListLast` → `front()`/`back()` on a possibly-empty vector (UB).
- `ListAt` → `vec.at(idx)`, whose `std::out_of_range` escaped to the top-level `bbruntime_run` catch and terminated the whole program with an STL string.

Added two inline guards — `listIndexOk()` and `listNotEmpty()` — mirroring the established bank/stream idiom (`bbbank.cpp` `debugBank`): `debug ? RTEX(clean message) : errorLog + safe default`. Applied to `_bbVectorAt` (now `[]` after the check), `_bbVectorBack`/`_bbVectorFirst`, `_bbVectorRemove`/`_bbVectorReplace`, and `_bbVectorInsert` (which correctly allows the append position `idx == size` and rejects `idx > size`). Happy-path behaviour is byte-identical. BBList is a BlitzForge-specific API, so there's no legacy-Blitz3D compatibility risk.

## Acceptance criteria + results

- [x] Out-of-range/negative `ListAt` returns `Null` and the program keeps running (pre-fix it crashed the whole run) — new `testListAtOutOfRange`.
- [x] `ListFirst`/`ListLast` on an empty list return `Null`, no UB — `testListFirstLastEmpty`.
- [x] Out-of-range `ListRemove`/`ListReplace` are no-ops, size + contents unchanged — `testListRemoveReplaceOutOfRange`.
- [x] `ListInsert` accepts `idx == ListSize` (append) and rejects `idx > ListSize` / negative — `testListInsertBoundary`.
- [x] All existing `ListTest.bb` happy-path blocks pass unmodified; full `test.bat` green; local build 0 errors; corpus sweep unaffected.

Note: the new tests run in `-t` mode where `debug` is false, so they exercise the soft-fail (no-op + safe default) path; the blocks *completing* is the regression guard, since the pre-fix `ListAt` out-of-range aborted the process. In a `-d` debug build the same inputs raise a clean Blitz `RuntimeError`.

## Trade-offs, deferred follow-ups

- **Negative-index "count from end"** is a feature, not a fix — out of scope.
- **`_bbVectorClear` arg-count/shadow quirk** (`basic.cpp:882`: rtSym declares one arg, C fn takes two; inner `for` shadows the unused param) — harmless, pre-existing; flagged, not touched.
- Deferred (confirmed, next candidates): the `seTranslator` missing-`break` fix (`bbruntime_dll.cpp` — mislabels every native crash; verification path now known) and human-readable compiler diagnostics (source line + caret, sanitize EOF byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)