### PR TITLE
Close the out-of-bounds hole in ReadBytes/WriteBytes

### DIFF
--- a/docs/notes/readbytes-writebytes-bounds.md
+++ b/docs/notes/readbytes-writebytes-bounds.md
@@ -1,0 +1,80 @@
+# Working note — Close the OOB hole in ReadBytes / WriteBytes
+
+Branch: `fix/readbytes-writebytes-bounds`
+Type: Bug / Reliability (memory-safety)
+
+## Goal (restated)
+
+`bbReadBytes`/`bbWriteBytes` (`src/blitzrc/bbruntime/bbbank.cpp:170-184`) pass a
+caller-supplied `count` straight to `bbStream::read/write(char*, int)` after only a
+single composite `debugBank(b, offset+count-1, ...)` check — no `count <= 0` guard
+and no independent start-offset check. Two arbitrary out-of-bounds memory
+primitives reachable from pure Blitz code:
+- `ReadBytes(bank, s, 10, -5)` → composite index `4` is in range → passes →
+  `s->read(data+10, -5)`; the negative `count` widens to a huge `streamsize` →
+  massive OOB write into the bank.
+- `ReadBytes(bank, s, -100, 200)` → composite index `99` is in range → passes →
+  reads into `data-100` → OOB underflow.
+
+`bbCopyBank` (`bbbank.cpp:98-112`) already fixed this exact class (Round-4 audit):
+`if(count<=0) return;` then independent start AND end `debugBank` checks. ReadBytes/
+WriteBytes are the unfinished tail — they still carry the old dead `//if(debug){`
+scaffolding. INTENT: "no silent corruption … bounds checks always worth doing."
+
+## Approach
+
+Mirror `bbCopyBank` in both functions:
+```cpp
+int bbReadBytes( bbBank *b,bbStream *s,int offset,int count ){
+    if( count <= 0 ) return 0;
+    if (!debugBank( b,offset,"ReadBytes" )) return 0;            // start
+    if (!debugBank( b,offset+count-1,"ReadBytes" )) return 0;    // end
+    if (!debugStream( s,"ReadBytes" )) return 0;
+    return s->read( b->data+offset,count );
+}
+```
+…and the same for `bbWriteBytes`. Remove the dead `//if(debug){` / `//}` comments.
+`debugBank` is `debug ? RTEX : errorLog.push_back; return false` — in debug a bad
+index raises a clean RuntimeError; otherwise the call no-ops and returns 0.
+
+A huge positive `count` makes `offset+count-1` overflow to negative, which the
+end `debugBank` rejects (`offset<0`) — same behaviour as CopyBank; matching the
+established idiom over a bespoke overflow guard keeps the two paths consistent.
+
+## Files touched
+
+- `src/blitzrc/bbruntime/bbbank.cpp` — `bbReadBytes`, `bbWriteBytes`.
+- `tests/BankBoundsTest.bb` — add ReadBytes/WriteBytes cases.
+- `docs/notes/readbytes-writebytes-bounds.md` — this note.
+
+No public-API/ABI change; valid (positive, in-range) calls are byte-identical.
+
+## Acceptance criteria (Artifact B)
+
+- `WriteBytes`/`ReadBytes` with `count <= 0` return 0 without calling
+  `s->write`/`s->read`: verified by a `WriteBytes(..., -1)` leaving the output file
+  at `FileSize = 0`, and a `ReadBytes(..., -1)` leaving a sentinel-filled bank
+  unchanged. Both blocks complete (no crash) — the regression guard, since pre-fix
+  the negative count drove a huge OOB transfer.
+- Happy-path round-trip (bank → file via `WriteBytes`, file → bank via `ReadBytes`)
+  reproduces the bytes exactly.
+- Existing `BankBoundsTest.bb` (CopyBank) and full `test.bat` stay green; corpus
+  sweep unaffected.
+
+## Trade-offs / rejected
+
+- **Pile-on note:** last iteration (#73) was BBList bounds-checking; this is another
+  bounds fix. Weighed the loop's anti-pile-on bias and chose impact: a reachable
+  arbitrary OOB read/write (INTENT's non-negotiable "no silent corruption") outranks
+  the tunable heuristic, and this is a different module/function family completing a
+  committed audit. Deliberately steering to diagnostics/DevEx next iteration.
+- **Defense-in-depth negative-size guard inside `bbStream::read/write`** — broader,
+  out of scope; the fix at the bank boundary closes the Blitz-reachable hole.
+- Not touching CopyBank/Peek/Poke/`debugBank` (already correct).
+
+## Deferred follow-ups
+
+- `seTranslator` missing `break`s (Bug, confirmed, verification path known).
+- Human-readable compiler diagnostics (source line + caret, `blitzide`-gated).
+- `qstreambuf` `new[]`/`delete` mismatch (`stdutil.cpp` ~419/447) — narrower UB,
+  flagged by recon, harder to exercise from Blitz.

--- a/src/blitzrc/bbruntime/bbbank.cpp
+++ b/src/blitzrc/bbruntime/bbbank.cpp
@@ -168,18 +168,23 @@ void  bbPokeFloat( bbBank *b,int offset,float value ){
 }
 
 int   bbReadBytes( bbBank *b,bbStream *s,int offset,int count ){
-	//if( debug ){
+	// Same audit class as bbCopyBank: a negative count widens to a huge
+	// std::streamsize in the stream layer (arbitrary OOB read/write), and the
+	// single composite `offset+count-1` check passed a valid index for a
+	// negative count or a negative offset with a compensating count. Reject
+	// count<=0 up front and validate the start and end offsets independently.
+	if( count <= 0 ) return 0;
+	if (!debugBank( b,offset,"ReadBytes" )) return 0;
 	if (!debugBank( b,offset+count-1,"ReadBytes" )) return 0;
 	if (!debugStream( s,"ReadBytes" )) return 0;
-	//}
 	return s->read( b->data+offset,count );
 }
 
 int   bbWriteBytes( bbBank *b,bbStream *s,int offset,int count ){
-	//if( debug ){
+	if( count <= 0 ) return 0;
+	if (!debugBank( b,offset,"WriteBytes" )) return 0;
 	if (!debugBank( b,offset+count-1,"WriteBytes" )) return 0;
 	if (!debugStream( s,"WriteBytes" )) return 0;
-	//}
 	return s->write( b->data+offset,count );
 }
 

--- a/tests/BankBoundsTest.bb
+++ b/tests/BankBoundsTest.bb
@@ -75,3 +75,84 @@ Test testCopyBankValidCopyStillWorks()
 	Assert(PeekByte(dest, 2) = 3)
 	Assert(PeekByte(dest, 3) = 4)
 End Test
+
+; --- ReadBytes / WriteBytes bounds (the unfinished tail of the bank audit) ---
+; These passed a caller-supplied count straight to the stream layer after only a
+; single composite offset+count-1 check: a negative count widened to a huge
+; streamsize (arbitrary OOB read/write), and a negative offset with a compensating
+; count passed the lone check. Now guarded like CopyBank (count<=0 + independent
+; start/end checks). The blocks completing is the regression guard -- pre-fix the
+; negative-count transfer drove an out-of-bounds memory access.
+
+Global bytesDir$ = CurrentDir$()
+
+Test testWriteReadBytesRoundTrip()
+	Local src.BBBank = CreateBank(4)
+	PokeByte src, 0, 11
+	PokeByte src, 1, 22
+	PokeByte src, 2, 33
+	PokeByte src, 3, 44
+
+	Local out.BBStream = WriteFile(bytesDir$ + "bytetest.dat")
+	WriteBytes src, out, 0, 4
+	CloseFile out
+
+	Local dest.BBBank = CreateBank(4)
+	Local inp.BBStream = ReadFile(bytesDir$ + "bytetest.dat")
+	ReadBytes dest, inp, 0, 4
+	CloseFile inp
+
+	Assert(PeekByte(dest, 0) = 11)
+	Assert(PeekByte(dest, 1) = 22)
+	Assert(PeekByte(dest, 2) = 33)
+	Assert(PeekByte(dest, 3) = 44)
+
+	DeleteFile(bytesDir$ + "bytetest.dat")
+End Test
+
+Test testWriteBytesNegativeCountIsNoOp()
+	Local src.BBBank = CreateBank(8)
+	Local i
+	For i = 0 To 7
+		PokeByte src, i, i
+	Next
+
+	Local out.BBStream = WriteFile(bytesDir$ + "byteneg.dat")
+	; Pre-fix: count=-1 widened to a huge size in the stream write -> OOB read of src.
+	WriteBytes src, out, 0, -1
+	CloseFile out
+
+	; Nothing was written.
+	Assert(FileSize(bytesDir$ + "byteneg.dat") = 0)
+
+	DeleteFile(bytesDir$ + "byteneg.dat")
+End Test
+
+Test testReadBytesNegativeCountIsNoOp()
+	; Seed a file with 8 known bytes.
+	Local src.BBBank = CreateBank(8)
+	Local i
+	For i = 0 To 7
+		PokeByte src, i, 7
+	Next
+	Local out.BBStream = WriteFile(bytesDir$ + "byteneg2.dat")
+	WriteBytes src, out, 0, 8
+	CloseFile out
+
+	; Fill dest with a sentinel, then ReadBytes with a negative count.
+	Local dest.BBBank = CreateBank(8)
+	For i = 0 To 7
+		PokeByte dest, i, 255
+	Next
+	Local inp.BBStream = ReadFile(bytesDir$ + "byteneg2.dat")
+	; Pre-fix: count=-1 -> OOB write into dest / crash.
+	ReadBytes dest, inp, 0, -1
+	CloseFile inp
+
+	; dest is unchanged.
+	For i = 0 To 7
+		Assert(PeekByte(dest, i) = 255)
+	Next
+
+	DeleteFile(bytesDir$ + "byteneg2.dat")
+End Test


### PR DESCRIPTION
## Non-technical summary

`ReadBytes`/`WriteBytes` (which transfer raw bytes between a memory bank and a file/socket stream) trusted the byte `count` you handed them. A negative count — or a negative offset with a compensating count — slipped past the single bounds check and drove an **out-of-bounds memory read/write** from ordinary Blitz code: an arbitrary read/write primitive. This PR closes that hole using the same guard pattern the project already applied to `CopyBank`. Advances INTENT's "no silent corruption — bounds checks always worth doing."

## Technical summary

`bbReadBytes`/`bbWriteBytes` in `src/blitzrc/bbruntime/bbbank.cpp` validated only the composite `debugBank(b, offset+count-1)` index — no `count<=0` guard, no independent start-offset check:
- `ReadBytes(bank, s, 10, -5)` → composite index `4` is in range → passes → `s->read(data+10, -5)`; the negative count widens to a huge `std::streamsize` → massive OOB write into the bank.
- `ReadBytes(bank, s, -100, 200)` → composite index `99` is in range → passes → reads into `data-100` → OOB underflow.

`bbCopyBank` (Round-4 audit) already fixed this exact class with `if(count<=0) return;` + independent start and end `debugBank` checks. ReadBytes/WriteBytes were the unfinished tail (they still carried the old dead `//if(debug){` scaffolding). This PR mirrors CopyBank's guards in both functions and removes the dead comments. In debug builds a bad index raises a clean Blitz `RuntimeError`; otherwise the call no-ops and returns 0. **Valid positive, in-range calls are byte-identical.**

## Acceptance criteria + results

- [x] `WriteBytes`/`ReadBytes` with `count <= 0` return 0 without touching the stream — verified: `WriteBytes(..., -1)` leaves the output `FileSize = 0`; `ReadBytes(..., -1)` leaves a sentinel-filled bank unchanged; both blocks complete (no crash) — the regression guard, since pre-fix the negative count drove an OOB transfer.
- [x] Happy-path round-trip (bank → file via `WriteBytes`, file → bank via `ReadBytes`) reproduces the bytes exactly.
- [x] Existing `BankBoundsTest.bb` (CopyBank) + full `test.bat` green; local build 0 errors; corpus sweep unaffected.

## Trade-offs, deferred follow-ups

- **Pile-on note (disclosed):** the prior iteration (#73) was BBList bounds-checking; this is another bounds fix. I weighed the loop's anti-pile-on bias and chose impact — a reachable arbitrary OOB read/write outranks the heuristic, and this is a different module/function family completing a committed audit. Next iteration will deliberately steer to a different area (diagnostics/DevEx).
- Out of scope: defense-in-depth negative-size guards inside `bbStream::read/write`; CopyBank/Peek/Poke (already correct).
- Deferred (confirmed): `seTranslator` missing-`break` (mislabels native crashes); human-readable compiler diagnostics (source line + caret, `blitzide`-gated); `qstreambuf` `new[]`/`delete` mismatch (`stdutil.cpp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)