### PR TITLE
Human-readable terminal compiler diagnostics (IDE format preserved)

### DIFF
--- a/docs/notes/readable-compiler-diagnostics.md
+++ b/docs/notes/readable-compiler-diagnostics.md
@@ -1,0 +1,84 @@
+# Working note — Human-readable compiler diagnostics (terminal), IDE format preserved
+
+Branch: `devex/readable-compiler-diagnostics`
+Type: DevEx / UX (with a Bug fix: the EOF-byte leak)
+
+## Goal (restated)
+
+When `blitzcc` rejects a `.bb` from the terminal, the only output is a single
+machine line: `"file":row:col:row:col:msg` (`main.cpp:342-348`). A human gets no
+source context — no offending line, no caret. Worse, unterminated-block/EOF errors
+leak a raw `0xFF` byte into the message (`parser.cpp:62` concatenates
+`toker->text()`, which at EOF is `line.substr(0,1)` where `line[0]=(char)EOF`).
+
+Render a clang-style diagnostic (source line + `^` caret) for terminal users,
+gated behind `getenv("blitzide")` so the IDE machine format stays byte-identical;
+and fix the EOF-byte leak at its source. This is the DevEx increment the prior
+iteration explicitly pre-planned, and it deliberately steers away from the recent
+runtime-bounds theme.
+
+## Why it's safe to change terminal output
+
+- The IDE/VS Code extension and rcce2 tooling consume the machine format; it is
+  preserved byte-for-byte behind `getenv("blitzide")` (the same env var already
+  used at `main.cpp:292`).
+- CI/`test.bat` assert only exit codes and the substrings `Usage:`,
+  `Compiler version:`, `Unsupported -target` — never the compile-error line. So
+  changing terminal error output cannot break the existing contract.
+
+## Approach (in order)
+
+1. **`toker.cpp` `Toker::textAt`** — return the literal `"<end of file>"` when the
+   token is the EOF token (`tokes[toke].n == EOF`), so the `0xFF` byte never
+   reaches any message (`Got:` text or `identifier near:`). Mode-independent fix.
+2. **`main.cpp` `catch(Ex&)`** — branch on `getenv("blitzide")`:
+   - IDE present → emit the exact current `"file":row:col:row:col:msg` line, unchanged.
+   - Terminal → `file:row:col: error: msg`, then re-read the offending source line
+     from `x.file` and print it with a `^` caret aligned to `col` (tabs copied
+     verbatim into the caret line so alignment holds under tab expansion). If
+     `x.pos < 0` (assembler/fileless errors) or the line can't be read, print the
+     message header only — never crash, never a bogus caret.
+3. **`test.bat` + `test.sh`** — add CLI-contract checks: generate a broken fixture
+   in a temp dir (NOT under `tests/`, so the `-t` loop and corpus sweep don't pick
+   it up), then assert terminal mode shows `error:` and `end of file`, and IDE mode
+   (`blitzide` set) still emits the machine format and omits the `error:` prefix.
+
+## Files touched
+
+- `src/blitzrc/compiler/toker.cpp` — `textAt` EOF-token text.
+- `src/blitzrc/blitz/main.cpp` — the compile-error catch block (+ `<cstdlib>` if
+  `getenv` isn't already in scope).
+- `test.bat`, `test.sh` — CLI diagnostic contract checks.
+- `docs/notes/readable-compiler-diagnostics.md` — this note.
+
+No `Ex` struct / pos-encoding change; no parser/sema/codegen change beyond the EOF
+token text; no new CLI flags; the `blitzide` env var is the sole gate.
+
+## Acceptance criteria (Artifact B)
+
+- With `blitzide` set, a broken `.bb` produces output byte-identical to current
+  `develop` (machine format), and does NOT contain the human `error:` prefix.
+- Without `blitzide`, the same file prints `file:row:col: error: msg`, the offending
+  source line, and a caret; exit code unchanged (non-zero).
+- An unterminated block (`For` with no `Next`) reports `... Got: <end of file>` —
+  no raw control byte — in both modes.
+- `x.pos < 0` errors print message-only without crashing.
+- `test.bat` (and `test.sh`) stay green with the new checks; corpus sweep unaffected.
+
+## Trade-offs / rejected
+
+- **Rejected this iteration: the legacy-identifier contextual-keyword fix**
+  (recon, INTENT #1, breaks shipped samples). Highest *alignment*, but front-end
+  grammar surgery with real ambiguity/regression risk — it keeps failing the
+  "high-confidence COMPLETE one-iteration" bar (deferred 3x). It needs a DEDICATED
+  iteration with the phased statement-only scope; flagging it so it doesn't become
+  a perennial defer.
+- **Rejected: seTranslator missing-`break`** — trivial/confirmed but lowest impact
+  (cosmetic message on an already-fatal crash). Cheap future pick.
+- No ANSI color (portability + log-capture noise); plain-text caret only.
+
+## Deferred follow-ups
+
+- Legacy-identifier compatibility (DEDICATED iteration, statement-only phase first).
+- `seTranslator` missing `break`s.
+- `qstreambuf` `new[]`/`delete` mismatch (`stdutil.cpp` ~419/447).

--- a/src/blitzrc/blitz/main.cpp
+++ b/src/blitzrc/blitz/main.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iostream>
 #include <iomanip>
+#include <cstdlib>
 
 using namespace std;
 
@@ -340,10 +341,36 @@ int _cdecl main( int argc,char *argv[] ){
 		assem.assemble();
 		
 	}catch( Ex &x ){
-		
-		string file='\"'+x.file+'\"';
+
 		int row=((x.pos>>16)&65535)+1,col=(x.pos&65535)+1;
-		cout<<file<<":"<<row<<":"<<col<<":"<<row<<":"<<col<<":"<<x.ex<<endl;
+
+		if( getenv( "blitzide" ) ){
+			// The IDE / VS Code extension parses this exact machine-readable
+			// format -- keep it byte-for-byte identical.
+			string file='\"'+x.file+'\"';
+			cout<<file<<":"<<row<<":"<<col<<":"<<row<<":"<<col<<":"<<x.ex<<endl;
+		}else{
+			// Human at the terminal: a clang-style diagnostic with the offending
+			// source line and a caret. Falls back to message-only when there is
+			// no position (assembler/fileless errors) or the line can't be read.
+			if( x.pos<0 || x.file.empty() ){
+				cout<<"error: "<<x.ex<<endl;
+			}else{
+				cout<<x.file<<":"<<row<<":"<<col<<": error: "<<x.ex<<endl;
+				ifstream src( x.file.c_str() );
+				string line;int cur=0;bool got=false;
+				while( getline( src,line ) ){ if( ++cur==row ){ got=true;break; } }
+				if( got ){
+					if( line.size() && line[line.size()-1]=='\r' ) line.resize( line.size()-1 );
+					cout<<"  "<<line<<endl;
+					string caret="  ";
+					for( int i=0;i<col-1 && i<(int)line.size();++i )
+						caret += (line[i]=='\t') ? '\t' : ' ';
+					caret+='^';
+					cout<<caret<<endl;
+				}
+			}
+		}
 		exit(-1);
 	}
 

--- a/src/blitzrc/compiler/toker.cpp
+++ b/src/blitzrc/compiler/toker.cpp
@@ -142,6 +142,10 @@ string Toker::text(){
 
 string Toker::textAt(int toke) {
 	if (toke >= tokes.size()) return "";
+	// The EOF token's source byte is (char)EOF (0xFF); rendering it verbatim in
+	// an error message ("Expecting 'Next' Got: <0xFF>") leaks a control byte to
+	// the terminal/log. Show a readable token instead.
+	if( tokes[toke].n==EOF ) return "<end of file>";
 	int from=tokes[toke].from,to=tokes[toke].to;
 	return line.substr( from,to-from );
 }

--- a/test.bat
+++ b/test.bat
@@ -14,6 +14,15 @@ call :expect_success "host alias compiles NumberTest" -c +q -target host "%SAMPL
 call :expect_success "native Windows target compiles NumberTest" -c +q -target windows-x86 "%SAMPLE%"
 call :expect_failure "foreign macOS target is rejected" "Unsupported -target" -c +q -target macos-arm64 "%SAMPLE%"
 
+rem --- compiler diagnostic contract (human terminal output vs IDE machine format) ---
+rem Generate a broken fixture OUTSIDE tests\ so the -t loop and corpus sweep ignore it.
+set "DIAG_BB=%TEMP%\blitzforge-diag-%RANDOM%-%RANDOM%.bb"
+> "!DIAG_BB!" echo For i = 1 To 10
+call :expect_failure "terminal diagnostic shows human error: prefix" "error:" -c +q "!DIAG_BB!"
+call :expect_failure "EOF error names end of file, not a control byte" "end of file" -c +q "!DIAG_BB!"
+call :expect_ide_format "IDE machine format preserved under blitzide" "!DIAG_BB!"
+del /q "!DIAG_BB!" >nul 2>&1
+
 cd /d "%ROOTDIR%\tests"
 
 for /R %%f in (*.bb) do (
@@ -99,4 +108,29 @@ if !CLI_RC! NEQ 0 (
 )
 del /q "!CLI_LOG!" >nul 2>&1
 rmdir /s /q "!CLI_DIR!" >nul 2>&1
+exit /b 0
+
+:expect_ide_format
+rem With blitzide set, the compile-error output must stay the machine-readable
+rem format the IDE parses (no human "error:" prefix). The message ("Expecting...")
+rem appears in both modes; the "error:" prefix only in terminal mode.
+set "LABEL=%~1"
+set "IDE_BB=%~2"
+set "IDE_LOG=%TEMP%\blitzforge-ide-%RANDOM%-%RANDOM%.log"
+set "blitzide=1"
+"%BLITZPATH%\bin\blitzcc.exe" -c +q "!IDE_BB!" >"!IDE_LOG!" 2>&1
+set "blitzide="
+findstr /C:"Expecting" "!IDE_LOG!" >nul
+if errorlevel 1 (
+    echo IDE contract FAILED: !LABEL! produced no diagnostic
+    type "!IDE_LOG!"
+    set FAILED=1
+)
+findstr /C:"error:" "!IDE_LOG!" >nul
+if not errorlevel 1 (
+    echo IDE contract FAILED: !LABEL! leaked the human "error:" prefix into IDE output
+    type "!IDE_LOG!"
+    set FAILED=1
+)
+del /q "!IDE_LOG!" >nul 2>&1
 exit /b 0

--- a/test.sh
+++ b/test.sh
@@ -128,6 +128,47 @@ else
   run_target_expect_failure "foreign macOS target is rejected" -target macos-arm64
 fi
 
+# --- compiler diagnostic contract: human terminal output vs IDE machine format ---
+# A broken fixture (unterminated For) outside tests/ so it is not picked up by the
+# -t loop. Terminal mode prints a human "error:" diagnostic and never a raw control
+# byte for the EOF token; IDE mode (blitzide set) keeps the machine format the
+# editor parses (no "error:" prefix).
+DIAG_BB="${TEST_TMPDIR}/diag.bb"
+printf 'For i = 1 To 10\n' > "${DIAG_BB}"
+
+set +e
+( unset blitzide; "${BLITZCC}" -c +q "${DIAG_BB}" ) > "${TEST_TMPDIR}/diag-term.out" 2>&1
+set -e
+if ! grep -q "error:" "${TEST_TMPDIR}/diag-term.out"; then
+  echo "diagnostic contract FAILED: terminal output missing human 'error:' prefix" >&2
+  cat "${TEST_TMPDIR}/diag-term.out" >&2
+  FAILED=1
+fi
+if ! grep -q "end of file" "${TEST_TMPDIR}/diag-term.out"; then
+  echo "diagnostic contract FAILED: EOF error did not render '<end of file>'" >&2
+  cat "${TEST_TMPDIR}/diag-term.out" >&2
+  FAILED=1
+fi
+# A literal 0xFF byte must not appear (the pre-fix EOF-token leak).
+if LC_ALL=C grep -q "$(printf '\377')" "${TEST_TMPDIR}/diag-term.out"; then
+  echo "diagnostic contract FAILED: terminal output leaked a 0xFF control byte" >&2
+  FAILED=1
+fi
+
+set +e
+blitzide=1 "${BLITZCC}" -c +q "${DIAG_BB}" > "${TEST_TMPDIR}/diag-ide.out" 2>&1
+set -e
+if ! grep -q "Expecting" "${TEST_TMPDIR}/diag-ide.out"; then
+  echo "diagnostic contract FAILED: IDE mode produced no diagnostic" >&2
+  cat "${TEST_TMPDIR}/diag-ide.out" >&2
+  FAILED=1
+fi
+if grep -q "error:" "${TEST_TMPDIR}/diag-ide.out"; then
+  echo "diagnostic contract FAILED: IDE mode leaked the human 'error:' prefix" >&2
+  cat "${TEST_TMPDIR}/diag-ide.out" >&2
+  FAILED=1
+fi
+
 while IFS= read -r -d '' f; do
   if ! "${BLITZCC}" "${TARGET_FLAG[@]}" "${EXEC_FLAG[@]}" -t "${f}"; then
     echo "\"${f}\" failed at least one test"


### PR DESCRIPTION
## Non-technical summary

Run `blitzcc` on a `.bb` with a typo and, until now, all you got at the terminal was a cryptic machine line — `"file":row:col:row:col:msg` — with no source context, and unterminated-block errors even printed a raw garbage control byte. This is the first thing a returning Blitz user hits. This PR makes terminal errors clang-style: the file/line/column, the **offending source line**, and a **`^` caret** pointing at the problem — while keeping the exact machine format the IDE/VS Code extension parses. Advances INTENT #6 ("no more 'it crashed and the log says nothing'") and day-one onboarding.

## Technical summary

- **`main.cpp` `catch(Ex&)`** — branch on `getenv("blitzide")` (the env var already used at `main.cpp:292`):
  - **IDE present** → the exact current `"file":row:col:row:col:msg` line, byte-for-byte unchanged (the extension and rcce2 tooling parse it).
  - **Terminal** → `file:row:col: error: msg`, then the source line re-read from `x.file` and a `^` caret aligned to the column (tabs copied verbatim so alignment holds under tab expansion). Falls back to message-only when `x.pos<0` (assembler/fileless errors) or the line can't be read — never crashes, never a bogus caret.
- **`toker.cpp` `textAt()`** — render the EOF token as the literal `<end of file>` so the `0xFF` byte never reaches a message (fixes the leak in **both** output modes — `parser.cpp` built `Got: ` + `toker->text()`, which at EOF was the EOF byte).
- No `Ex`/pos-encoding change; no parser/sema/codegen change beyond the EOF token text; no new CLI flags.

**Verified manually (both modes):** terminal → `…/diag2.bb:1:1: error: Function 'foo' not found` + source line + caret; `Print )` → caret under the `)` at col 7; IDE (`blitzide=1`) → byte-identical machine line, no `error:` prefix; EOF errors render `Got: <end of file>` in both.

## Acceptance criteria + results

- [x] With `blitzide` set, output is the unchanged machine format and omits the human `error:` prefix.
- [x] Without `blitzide`, output shows `file:row:col: error: msg` + source line + caret.
- [x] Unterminated block reports `Got: <end of file>` — no raw control byte — in both modes.
- [x] `x.pos<0` errors print message-only without crashing (fallback path).
- [x] New CLI-contract checks in `test.bat` (+ an `:expect_ide_format` helper) and `test.sh`, using a broken fixture generated outside `tests/` so the `-t` loop and corpus sweep ignore it. Full `test.bat` green; build 0 errors; corpus sweep unaffected.

## Trade-offs, deferred follow-ups

- **Why this, not the legacy-identifier compat fix (INTENT #1):** that remains the highest-*alignment* item, but it's front-end grammar surgery with real ambiguity/regression risk and keeps failing the "high-confidence complete one-iteration" bar. It needs a **dedicated** iteration (phased: statement-only keywords first) — flagged in memory so it doesn't become a perennial defer, not rushed here alongside an unrelated change.
- The terminal diagnostic points the caret at the error's reported column; some semantic errors report the statement-start column rather than the exact token (pre-existing `Ex` position behavior) — out of scope.
- No ANSI color (portability + log-capture noise).
- Deferred: `seTranslator` missing-`break`; `qstreambuf` `new[]`/`delete` mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)