### PR TITLE
Restore drop-in compatibility: make 'Test' a contextual keyword (legacy identifiers compile)

### DIFF
--- a/docs/notes/legacy-test-keyword-identifier.md
+++ b/docs/notes/legacy-test-keyword-identifier.md
@@ -1,0 +1,79 @@
+# Working note — Contextual `Test` keyword (legacy-identifier compatibility, Phase 1)
+
+Branch: `align/legacy-test-keyword-identifier`
+Type: Feature / Alignment (drop-in source compatibility, INTENT #1)
+
+## Goal (restated)
+
+BlitzForge reserves its additive keywords globally in the tokenizer, so legacy
+Blitz3D programs that use those words as ordinary identifiers fail to compile —
+violating INTENT value #1 ("Drop-in source compatibility… Always"). This is the
+corpus allowlist's Class A and has been deferred 4×; this iteration commits to it
+with a de-risked **Phase 1: make `Test` contextual** (the dominant collision).
+
+`Test` is the keyword ONLY as a statement-start block opener (`Test <ident>(` …
+`End Test`). Used any other way — assignment target, call, parameter name, type
+tag, or expression operand — it must be an ordinary identifier.
+
+Phase 1 clears 4 of the 6 Class A allowlist entries (the `test=…` /
+`test.Timer` files). Deferred: `Release` (expression-position keyword — needs
+`parseUniExpr` lookahead), `object` (a *legacy* Blitz3D keyword, not a fork
+addition — out of scope), `Method`/others.
+
+## Approach (3 unified identifier-consumption sites in `parser.cpp`)
+
+1. **Statement dispatch** (~line 153): before `switch`, compute
+   `stmtTok = curr(); if (stmtTok==TEST && !(scope==STMTS_PROG && lookAhead(1)==IDENT)) stmtTok=IDENT;`
+   and `switch(stmtTok)`. So `test=100` / `test\f=…` / `test(…)` route to the
+   existing `case IDENT` statement logic (which reads `toker->text()` = "test"),
+   while `Test foo() … End Test` still hits `case TEST`.
+2. **`parseIdent()`** (line 65): accept `TEST` as an identifier
+   (`curr()!=IDENT && curr()!=TEST`). Covers parameter names (`test.Timer`),
+   `Local/Global/Field test`, type tags, labels — positions where `Test` can never
+   be the block keyword (the dispatcher already consumed it if it were).
+3. **Expression primary** (~line 1123): `case TEST:` falls through to `case IDENT:`
+   so `test` is a valid operand (`x = test + 1`, `Assert(test = 42)`).
+
+No tokenizer change. No new keyword removed from `makeKeywords()` (so `Test`/
+`End Test` stay reserved tokens — they're just now also accepted as identifiers
+where a block opener is impossible).
+
+## Files touched
+
+- `src/blitzrc/compiler/parser.cpp` — the 3 sites above.
+- `tests/LegacyKeywordIdentifierTest.bb` — new: `test` as local/assignment/operand/param,
+  alongside the `Test … End Test` block still working.
+- `scripts/corpus_compile_allowlist.txt` — remove the 4 `Test`-collision Class A
+  entries **only after** the sweep confirms each compiles cleanly.
+- `docs/notes/legacy-test-keyword-identifier.md` — this note.
+
+## Acceptance criteria (Artifact B)
+
+- `printf 'test=100\nEnd\n' | blitzcc -c +q` compiles (currently "Expecting identifier").
+- The 4 `Test`-collision samples compile under the corpus sweep; their allowlist
+  lines are removed and `sweep_corpus.sh` stays green (0 new-fail).
+- New `tests/LegacyKeywordIdentifierTest.bb` passes under `blitzcc -t`: `test` works
+  as a local, assignment target, expression operand, and function parameter; a
+  `Test … End Test` block in the same file still parses and runs.
+- The ENTIRE existing `tests/*.bb` suite still passes (every file uses `Test`/
+  `End Test` — maximal regression net). `test.bat` green; build 0 errors.
+
+## Trade-offs / rejected
+
+- **Phase 1 = `Test` only.** `Release` (spindisc.bb) is an expression-position
+  keyword needing `parseUniExpr` disambiguation → Phase 2. `object` (CraftFlare.bb)
+  is a legacy Blitz3D keyword, not a fork regression → out of scope. `Method` can
+  silently terminate the method-parse loop if softened → deferred.
+- **Known residual (documented):** a legacy *bare call* `test foo` (function call
+  without parens, arg `foo`) at statement start would still be read as a block
+  opener (`TEST` followed by IDENT). Not present in the corpus; statement-call of a
+  function literally named `test` with a bare identifier arg is vanishingly rare.
+- **Mechanism: parser-site acceptance, not a tokenizer rewrite** — keeps `Test`/
+  `End Test` reserved and the block grammar intact; lowest blast radius.
+
+## Deferred follow-ups (Phase 2+)
+
+- `Release`/`Recast`/`Reference`/`Assert`/`Ptr` — expression-position contextual
+  keywords (need `parseUniExpr` + the `Assert` token pre-scan handled).
+- `Method`/`End Method` contextual (subtle: method-loop termination).
+- `object` is legacy-keyword behavior, not in scope.

--- a/scripts/corpus_compile_allowlist.txt
+++ b/scripts/corpus_compile_allowlist.txt
@@ -20,12 +20,11 @@
 # that classic Blitz3D allowed as identifiers. The HIGH-priority contextual-keyword
 # fix would re-enable these. (`object` is a legacy Blitz3D keyword, not a fork
 # addition, but the program still uses it as an identifier.)
-samples/Blitz 2D Samples/fileio.bb        # 'test=' — test is now the Test keyword
-samples/Blitz 2D Samples/global.bb        # 'test=100'
-samples/Blitz 2D Samples/spindisc.bb      # 'release=1' — release is now the Release keyword
-samples/Blitz 3D Samples/birdie/Mirror/mirror.bb              # 'test=CreateCube()'
-samples/Blitz 3D Samples/Hi-Toro/Death Island/deathisland.bb  # 'test.Timer' parameter name
-samples/Blitz 3D Samples/RobHutchinson/CraftFlare/CraftFlare.bb  # 'object' identifier (legacy keyword)
+# NOTE: the four `test`-collision files (fileio/global/mirror/deathisland) were
+# removed once `Test` became a contextual keyword (PR: align/legacy-test-keyword-identifier);
+# they now compile. `release` and `object` remain (see below).
+samples/Blitz 2D Samples/spindisc.bb      # 'release=1' — Release is still a hard keyword (Phase 2: expression-position contextual)
+samples/Blitz 3D Samples/RobHutchinson/CraftFlare/CraftFlare.bb  # 'object' identifier (legacy Blitz3D keyword, not a fork addition)
 
 # --- Class B: disabled / unregistered builtin --------------------------------
 # Legacy Blitz3D builtins that are commented out or never registered in this

--- a/src/blitzrc/compiler/parser.cpp
+++ b/src/blitzrc/compiler/parser.cpp
@@ -63,7 +63,11 @@ void Parser::exp( const string &s ){
 }
 
 string Parser::parseIdent(){
-	if( toker->curr()!=IDENT ) exp( "identifier near: " + toker->text() );
+	// 'Test' is a contextual keyword: it is only the test-block opener at
+	// statement start (handled in parseStmtSeq). In every identifier position --
+	// parameter names, Local/Global/Field declarations, type tags, labels -- it is
+	// an ordinary identifier, so legacy programs using `test` as a name compile.
+	if( toker->curr()!=IDENT && toker->curr()!=TEST ) exp( "identifier near: " + toker->text() );
 	string t=toker->text();
 	if (t.find(":") != std::string::npos) ex( "Identifiers cannot include the : character");
 	toker->next();
@@ -150,7 +154,15 @@ void Parser::parseStmtSeq( StmtSeqNode *stmts,int scope ){
 			toker->next();
 		}
 
-		switch( toker->curr() ){
+		// 'Test' is a contextual keyword: it opens a test block only in the form
+		// `Test <ident>(` at program scope. Used as an assignment target, call,
+		// or with a type tag/field, it is an ordinary identifier -- so legacy
+		// Blitz3D programs that use `test` as a variable still compile (drop-in
+		// source compatibility). Route those uses through the IDENT statement path.
+		int stmtTok = toker->curr();
+		if( stmtTok==TEST && !(scope==STMTS_PROG && toker->lookAhead(1)==IDENT) ) stmtTok=IDENT;
+
+		switch( stmtTok ){
 		case INCLUDE:
 			{
 				if( scope!=STMTS_PROG ) ex( "'Include' can only appear in main program" );
@@ -1120,6 +1132,7 @@ ExprNode *Parser::parsePrimary( bool opt ){
 	case BBFALSE:
 		result=d_new IntConstNode( 0 );
 		toker->next();break;
+	case TEST:	// contextual keyword: usable as an identifier in expressions
 	case IDENT:
 		ident=toker->text();
 		toker->next();tag=parseTypeTag();

--- a/tests/LegacyKeywordIdentifierTest.bb
+++ b/tests/LegacyKeywordIdentifierTest.bb
@@ -1,0 +1,36 @@
+Strict
+EnableGC
+
+; Drop-in compatibility: 'Test' is one of BlitzForge's added keywords, but legacy
+; Blitz3D programs use `test` as an ordinary variable/parameter name. It must work
+; as an identifier everywhere it is not the test-block opener (`Test <name>()`),
+; while the test-block syntax (which this very file relies on) still parses.
+
+Type LegacyHolder
+	Field value
+End Type
+
+; 'test' as a function parameter name, used as an expression operand in the body.
+Function withTestParam( test )
+	Return test + 1
+End Function
+
+Test legacyTestAsLocalAndAssignment()
+	; Local declaration named `test`, statement-start assignment, and use as an
+	; expression operand -- all positions that previously tokenized as the TEST
+	; keyword and failed with "Expecting identifier".
+	Local test = 41
+	test = test + 1
+	Assert( test = 42 )
+End Test
+
+Test legacyTestAsParameter()
+	Assert( withTestParam( 41 ) = 42 )
+End Test
+
+Test legacyTestFieldAccess()
+	; `test` as a type-instance variable plus field access on it.
+	Local test.LegacyHolder = New LegacyHolder()
+	test\value = 7
+	Assert( test\value = 7 )
+End Test


### PR DESCRIPTION
## Non-technical summary

BlitzForge's #1 promise is that old Blitz3D programs compile unchanged. But the fork added new keywords (`Test`, `Method`, `Release`, …) and reserved them **globally**, so a legacy program that uses one of those common words as a variable name no longer compiled — and this broke programs in BlitzForge's own bundled samples. This PR fixes the most common offender, `test`: `test=100` (and `test` as a parameter, field, or operand) compiles again, while the modern `Test … End Test` block syntax is fully preserved. Directly advances INTENT value #1 ("Drop-in source compatibility. Always.").

## Technical summary

`Test` is now a **contextual keyword**: it's the keyword only as a statement-start block opener (`Test <ident>(` … `End Test`); everywhere else it's an ordinary identifier. Three unified sites in `src/blitzrc/compiler/parser.cpp`:
- **`parseStmtSeq` dispatch**: route the `TEST` token through the existing `case IDENT` statement path unless it's the block form (`scope==STMTS_PROG && lookAhead(1)==IDENT`). So `test=100`, `test\field=…`, `test(…)` parse as identifier statements (the `IDENT` case reads `toker->text()` == `"test"`).
- **`parseIdent()`**: accept `TEST` as an identifier — parameter names (`test.Timer`), `Local/Global/Field` declarations, type tags — positions where `Test` can never be a block opener.
- **`parseUniExpr` primary**: `case TEST` falls through to `case IDENT`, so `test` is a valid expression operand (`x = test + 1`).

No tokenizer change — `Test`/`End Test` stay reserved tokens and the block grammar is intact. Because every `tests/*.bb` file uses `Test`/`End Test`, the existing suite is a maximal regression net (all green).

**Phase 1** of the contextual-keyword work. Deferred: `Release` (expression-position keyword — needs `parseUniExpr` disambiguation, Phase 2) and `object` (a *legacy* Blitz3D keyword, not a fork addition — out of scope).

## Acceptance criteria + results

- [x] `printf 'test=100\nEnd\n' | blitzcc -c +q` compiles (was "Expecting identifier") — verified, rc=0.
- [x] The four `test`-collision samples (`global.bb`, `fileio.bb`, `mirror.bb`, `deathisland.bb`) compile; removed from `scripts/corpus_compile_allowlist.txt`; **corpus sweep green** with the trimmed list (0 new-fail, 0 stale).
- [x] New `tests/LegacyKeywordIdentifierTest.bb` passes: `test` as local / assignment target / operand / field-typed var / function parameter, alongside a working `Test … End Test` block.
- [x] Entire existing `tests/*.bb` suite still passes (`Test`/`End Test` regression net); `test.bat` green; build 0 errors.

## Trade-offs, deferred follow-ups

- **Known residual (documented):** a legacy *bare call* `test foo` (function call without parens, arg `foo`) at statement start would still read as a block opener (`TEST` followed by `IDENT`). Not present in the corpus; calling a function literally named `test` with a bare identifier arg is vanishingly rare.
- **Phase 2:** `Release` (spindisc.bb) and the other expression-position contextual keywords (`Recast`/`Reference`/`Assert`/`Ptr`) need `parseUniExpr` lookahead (and `Assert` has a token pre-scan). `Method`/`End Method` softening is subtler (method-loop termination). `object` is legacy-keyword behavior, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)