### PR TITLE
Pin the real GC ref-count contract + correct the GC reference docs

### DIFF
--- a/docs/notes/gc-refcount-contract.md
+++ b/docs/notes/gc-refcount-contract.md
@@ -1,0 +1,92 @@
+# Working note — Correct the GC doc & pin the real ref-count contract
+
+Branch: `test/gc-refcount-contract`
+Type: Documentation (correctness) + Test coverage
+
+## Goal (restated)
+
+Fix a shipped-doc correctness defect I introduced in PR #67:
+`help/language/lang_ref_modern.html` (GC section, ~lines 50-57) makes two claims
+that do NOT match the actual runtime, and cites `tests/GarbageCollectionTest.bb`
+as evidence for a contract that test never exercises:
+1. "RefCount reports how many references currently keep an object alive" — implies
+   it counts every alias. It does not.
+2. "reference cycles … are not collected automatically — break the cycle yourself"
+   — cycles of field references ARE collected at scope exit in this runtime.
+
+Correct the doc to match empirically-verified behavior, and expand the cited test
+so it actually demonstrates the contract.
+
+## Empirically verified (current `bin/blitzcc.exe`, via scratch `.bb` probes)
+
+- `Local a.T = New T()` → `RefCount(a) = 1`; at scope exit the object is collected
+  (`First T = Null`, `RefCount(First T) = 0`).
+- Local aliasing `Local b.T = a` does NOT change the count → `RefCount(a)` stays 1.
+- Field assignment `a\other = b` does NOT increment the count either.
+- A field-reference cycle (`a\other=b : b\other=a`, both function-locals) is
+  COLLECTED at scope exit — `First T = Null`, `Each T` count 0. **No leak.**
+- An object referenced only via another live object's field stays alive and
+  readable while the owner is reachable (`Each T` count 2; `container\other\tag`
+  readable).
+
+Mechanism context (do NOT change): `_bbReference`/`_bbRelease`/`_bbReferenceCount`
+operate on `reference_map` (`basic.cpp:744-823`); local-alias and field
+assignments don't route through `_bbReference`, so `RefCount` reflects the
+binding/lifetime count, not an alias count. (There's a separate older
+`obj->ref_cnt` path; the `reference_map`-vs-`obj->ref_cnt` distinction is a deeper
+question — see deferred follow-ups. This increment pins observed behavior, it does
+not change the runtime.)
+
+## Approach
+
+1. **Expand `tests/GarbageCollectionTest.bb`** with blocks pinning the verified
+   behavior, using a distinct type per concern to avoid cross-block contamination:
+   - single ref = 1 (+ object exists);
+   - scope-exit collects (First = Null / RefCount = 0) — keep existing;
+   - aliasing does not increment RefCount (pins the narrow semantics);
+   - a field-reference cycle is collected at scope exit (no leak);
+   - a field-only-referenced object stays alive while its owner is reachable.
+   All assertions are captured from real runs, not assumed.
+2. **Correct `lang_ref_modern.html`** GC section: describe RefCount as the GC's
+   tracked reference/lifetime count (freed when the owning variable leaves scope),
+   not "how many references"; replace the false cycle-leak claim with the verified
+   behavior (cycles of field refs are collected; keep a live variable reference to
+   anything you need to retain); the citation now points to a test that actually
+   demonstrates these cases.
+
+## Files touched
+
+- `tests/GarbageCollectionTest.bb` (expand)
+- `help/language/lang_ref_modern.html` (GC section correction)
+- `docs/notes/gc-refcount-contract.md` (this note)
+
+No `src/` change. Counteracts the recent runtime/bug-fix theme (Test + Docs).
+
+## Acceptance criteria
+
+- Every new `Test` block passes under `blitzcc -t`, asserting empirically-captured
+  values (single=1, alias stays 1, cycle collected, field-ref object survives).
+- The doc no longer claims RefCount counts all aliases, no longer claims cycles
+  leak; its `tests/GarbageCollectionTest.bb` citation is now accurate.
+- `test.bat` green; corpus sweep unaffected; no `src/` change.
+
+## Trade-offs / rejected
+
+- **Rejected: a full idealized ref-count acceptance suite** asserting
+  aliasing→RefCount=2 etc. — the runtime does NOT behave that way; asserting it
+  would be wrong. Pin reality instead (the iteration-4 empirical-capture pattern).
+- **Rejected this iteration: SoundPan/ChannelPan restoration** (recon) — strong
+  INTENT-#1 corpus-closing pick, but touches the OpenAL audio backend + a macOS
+  stub and the panning correctness isn't CI-verifiable; deferred.
+- **Rejected this iteration: the TCP-socket UAF** (recon) — real bug, but socket
+  lifetime is hard to verify headlessly; deferred with the cited trace.
+
+## Deferred follow-ups
+
+- **GC soundness / `reference_map` vs `obj->ref_cnt`:** clarify whether the two
+  ref-count mechanisms should be unified, and whether field/alias references
+  SHOULD be counted. Potential correctness question (premature free / leak in
+  configurations not covered here). Needs a dedicated investigation — do NOT
+  rush a runtime change.
+- SoundPan/ChannelPan (corpus Class B + shipped-doc gap); TCP-socket UAF;
+  contextual-keyword Phase 2.

--- a/help/language/lang_ref_modern.html
+++ b/help/language/lang_ref_modern.html
@@ -47,14 +47,19 @@ content="text/html; charset=iso-8859-1">
       End Type<br>
       <br>
       Local t.TestType = New TestType()<br>
-      ; RefCount reports how many references currently keep an object alive<br>
+      ; RefCount reports the object's tracked reference count<br>
       Print RefCount( First TestType ) ; prints 1</i></p>
   </blockquote>
-  <p>When the last reference to an object goes away, the object is released
-    automatically. <i>RefCount</i> lets you inspect the live reference count, which
-    is useful when reasoning about ownership. Note that reference cycles
-    (objects that point at each other) are not collected automatically &mdash; break
-    the cycle yourself, or avoid the back-reference. <i>(tests/GarbageCollectionTest.bb)</i></p>
+  <p>An object is released automatically when the variable holding it goes out of
+    scope (or is reassigned). <i>RefCount</i> lets you inspect an object's tracked
+    reference count. Note that the count follows the object's lifetime binding, not
+    every alias: binding a second variable to the same object does not raise its
+    <i>RefCount</i>, and field assignments are not counted. A practical consequence
+    is that a reference <i>cycle</i> &mdash; two objects pointing at each other
+    through fields &mdash; is still collected when the holding variables leave
+    scope (the field back-references add no counts), so cycles do not leak. Keep a
+    live variable referencing anything you need to retain. <i>(see the contract
+    pinned in tests/GarbageCollectionTest.bb)</i></p>
 
   <p class="header">Type inheritance</p>
   <p>A type can extend another type by naming the parent with a <i>.</i> tag in its

--- a/tests/GarbageCollectionTest.bb
+++ b/tests/GarbageCollectionTest.bb
@@ -16,3 +16,67 @@ Test testRel()
     Local testType2.TestType = First TestType
     Assert(testType2 = Null)
 End Test
+
+; --- Reference-count contract (pins the behavior the language reference cites) ---
+; Each concern uses its own Type so the per-block object lists stay isolated.
+; All asserted values were captured from the live runtime, not assumed.
+
+Type GcAlias
+    Field var
+End Type
+
+; RefCount tracks the GC's reference/lifetime count, NOT a count of every alias:
+; binding a second local to the same object does not increment it. (This is also
+; why field-reference cycles below do not leak.)
+Test testAliasDoesNotIncrementRefCount()
+    Local a.GcAlias = new GcAlias()
+    Assert(RefCount(a) = 1)
+    Local b.GcAlias = a
+    Assert(RefCount(a) = 1)
+    Assert(NOT b = Null)
+End Test
+
+Type GcCycle
+    Field other.GcCycle
+End Type
+
+Function makeGcCycle()
+    Local a.GcCycle = new GcCycle()
+    Local b.GcCycle = new GcCycle()
+    a\other = b
+    b\other = a
+End Function
+
+; A reference cycle (two objects pointing at each other through fields) is
+; COLLECTED when the holding variables go out of scope -- it does not leak --
+; because field assignments are not ref-counted, so the cycle adds no references.
+Test testReferenceCycleIsCollected()
+    makeGcCycle()
+    Assert(First GcCycle = Null)
+    Local count = 0
+    For obj.GcCycle = Each GcCycle
+        count = count + 1
+    Next
+    Assert(count = 0)
+End Test
+
+Type GcField
+    Field other.GcField
+    Field tag
+End Type
+
+; An object referenced only through another live object's field stays alive and
+; readable as long as that owner is reachable.
+Test testFieldReferencedObjectStaysAlive()
+    Local container.GcField = new GcField()
+    container\tag = 100
+    container\other = new GcField()
+    container\other\tag = 200
+
+    Local count = 0
+    For obj.GcField = Each GcField
+        count = count + 1
+    Next
+    Assert(count = 2)
+    Assert(container\other\tag = 200)
+End Test


### PR DESCRIPTION
## Non-technical summary

The language reference's garbage-collection section (shipped in PR #67) made two claims that don't match how the runtime actually behaves, and cited a test that didn't prove them. This PR corrects the docs to the **empirically-verified** behavior and expands the cited test so it genuinely demonstrates the contract. Fixes a shipped doc-correctness defect (my own from #67) and turns the GC test from two trivial asserts into a real contract.

## Technical summary

Verified against the live runtime (scratch `.bb` probes), then pinned:
- **`RefCount` tracks the object's lifetime binding, not every alias** — `Local b.T = a` does **not** raise `RefCount(a)` (stays 1); field assignments aren't counted either.
- **A reference cycle is collected, not leaked** — `a\other=b : b\other=a` (function locals) → after scope exit `First T = Null`, `Each T` count 0. (The field back-references add no counts, so the cycle holds nothing alive.)
- **A field-only-referenced object stays alive** while its owner is reachable (count 2; `container\other\tag` readable).

**Changes:**
- `tests/GarbageCollectionTest.bb`: keep `testRef`/`testRel`; add `testAliasDoesNotIncrementRefCount`, `testReferenceCycleIsCollected`, `testFieldReferencedObjectStaysAlive` (one `Type` per concern to isolate per-type object lists).
- `help/language/lang_ref_modern.html`: correct the two inaccurate claims and repoint the citation at the now-demonstrating test.
- **No `src/` change** — this pins current behavior. The deeper `reference_map`-vs-`obj->ref_cnt` mechanism question (should aliases/fields be counted?) is flagged as a separate, deferred investigation; this PR does not change runtime semantics.

## Acceptance criteria + results

- [x] New `Test` blocks pass under `blitzcc -t`, asserting empirically-captured values (single=1, alias stays 1, cycle collected → count 0 / `First = Null`, field-ref object survives → count 2).
- [x] Doc no longer claims `RefCount` counts all aliases, no longer claims cycles leak; the `GarbageCollectionTest.bb` citation is now accurate.
- [x] `test.bat` green; corpus sweep unaffected; no `src/` change.

## Trade-offs, deferred follow-ups

- **Rejected** an idealized ref-count suite (aliasing→RefCount=2): the runtime doesn't behave that way; pinned reality instead (the empirical-capture pattern).
- **Deferred (real open question):** whether the `reference_map` ref-count *should* track aliases/field references (the `reference_map` vs older `obj->ref_cnt` distinction) — a potential GC-soundness/design question needing a dedicated investigation, not a rushed runtime change.
- Other deferred recon pitches this iteration: restore `SoundPan`/`ChannelPan` on the OpenAL backend (corpus Class B + shipped-doc gap); a TCP-socket UAF in `bbsockets.cpp`; contextual-keyword Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)