### PR TITLE
Restore SoundPan / ChannelPan on the OpenAL audio backend

### DIFF
--- a/docs/notes/restore-audio-pan.md
+++ b/docs/notes/restore-audio-pan.md
@@ -1,0 +1,81 @@
+# Working note — Restore SoundPan / ChannelPan on the OpenAL audio backend
+
+Branch: `align/restore-audio-pan`
+Type: Feature / Alignment (drop-in compat, INTENT #1) + Documentation-vs-reality fix
+
+## Goal (restated)
+
+`SoundPan` and `ChannelPan` are classic Blitz3D stereo-pan commands. BlitzForge
+still ships docs/examples for them (`help/commands/.../SoundPan.htm`, `ChannelPan.htm`)
+but the runtime neither registers nor implements them — casualties of the
+DirectSound→OpenAL port (the impls/registrations are commented out in `bbaudio.cpp`
+and the `setPan` virtual was dropped from `gxChannel`/`gxSound`). Legacy programs
+calling them fail to compile ("SoundPan not found"); these are corpus-allowlist
+Class B entries (`aristoids.bb`, `spider.bb`). Restore them.
+
+## Approach (per file)
+
+Only the Windows OpenAL backend implements these interfaces (verified: just
+`SampleChannel`/`StreamChannel` and `gxSoundSample`/`gxSoundStream`; the macOS
+`.mm` does not implement gxChannel/gxSound). So:
+
+1. `gxchannel.h`: add `virtual void setPan(float)=0;` to `gxChannel`; declare it on
+   `SampleChannel` and `StreamChannel`.
+2. `gxchannel.cpp`: implement `setPan` on both — OpenAL constant-power pan on a
+   listener-relative source: clamp pan∈[-1,1], `alSourcei(source,AL_SOURCE_RELATIVE,
+   AL_TRUE); alSource3f(source,AL_POSITION,pan,0,-sqrtf(1-pan*pan));`.
+3. `gxsound.h`: add `virtual void setPan(float)=0;` to `gxSound`; add a
+   `float def_pan;` to its protected members; declare `setPan` on both sound
+   classes.
+4. `gxsound.cpp`: init `def_pan=0` in both ctors; store it in `setPan`; apply
+   `retVal->setPan(def_pan)` in both `play()` paths (so `SoundPan` sets the default
+   for subsequently-played channels, matching Blitz3D semantics).
+5. `bbaudio.h`/`bbaudio.cpp`: uncomment `bbSoundPan` (guarded by `debugSound`) and
+   `bbChannelPan` (guarded by `gx_audio->verifyChannel`, matching the other channel
+   commands), and their two `rtSym` registrations.
+6. `scripts/corpus_compile_allowlist.txt`: remove `aristoids.bb`/`spider.bb` once
+   the sweep confirms they compile.
+7. `tests/AudioPanTest.bb`: a headless-safe smoke test (symbols resolve, tolerate a
+   Null sound/channel without crashing).
+
+`set3d`/pan interaction: both touch `AL_SOURCE_RELATIVE`+`AL_POSITION`; last-call-
+wins (store pan; the corpus samples use pan OR 3D, not both).
+
+## Verification (acceptance is CI-deterministic; audible is manual)
+
+- Build clean; `blitzcc` registers `SoundPan`/`ChannelPan`.
+- `spider.bb` now compiles → removed from the allowlist (ratchet enforces it).
+  `aristoids.bb`'s SoundPan blocker is resolved, but it ALSO uses `PlayMusic`
+  (a separate, still-disabled Class B builtin) — so it stays allowlisted with its
+  reason updated to PlayMusic. (Verified empirically; corpus sweep green.)
+- `tests/AudioPanTest.bb` passes under `-t` (no crash; headless-safe).
+- `test.bat` green.
+- **Audible pan correctness is NOT headless-verifiable** (no audio device in CI).
+  The OpenAL constant-power formula is standard and the source/relative-mode setup
+  is confirmed; audible verification is a documented manual Windows step.
+
+## Files touched
+
+`gxchannel.{h,cpp}`, `gxsound.{h,cpp}`, `bbaudio.{h,cpp}`, `scripts/corpus_compile_allowlist.txt`,
+`tests/AudioPanTest.bb`, this note. No compiler/codegen/front-end change.
+
+## Trade-offs / rejected
+
+- **Pure-virtual vs non-pure default:** chose pure-virtual on the base (only 4
+  concrete implementers exist, all updated here; forces correctness). No macOS
+  audio implementer exists, so no stub needed.
+- **Rejected this iteration:** linker `loadImage` PE-header hardening (recon — real
+  but weak verification, low practical payoff) and the `gxSoundSample::load`
+  short-filename crash (recon — real one-line bug but borderline-too-small and
+  uncertain headless testability). Both deferred.
+
+## Deferred follow-ups
+
+- `gxSoundSample::load` short-filename crash: `LoadSound("abc")` → `substr(size()-4)`
+  underflow → `std::out_of_range` → process kill. One-line guard
+  (`filename.size()<4 || ...`) at `gxsound.cpp:25`. Real, BASIC-reachable. STRONG
+  cheap next pick (same file).
+- Other Class B builtins (`PlayMusic`, `CreateListener`, `Load3DSound`, `StartNetGame`).
+- Linker `loadImage` hardening; TCP-socket UAF; GC `reference_map` soundness;
+  contextual-keyword Phase 2.
+- Audible pan verification (manual Windows listen).

--- a/scripts/corpus_compile_allowlist.txt
+++ b/scripts/corpus_compile_allowlist.txt
@@ -28,10 +28,10 @@ samples/Blitz 3D Samples/RobHutchinson/CraftFlare/CraftFlare.bb  # 'object' iden
 
 # --- Class B: disabled / unregistered builtin --------------------------------
 # Legacy Blitz3D builtins that are commented out or never registered in this
-# fork's runtime (e.g. SoundPan is commented out in bbruntime/bbaudio.cpp).
+# fork's runtime (e.g. PlayMusic / CreateListener / Load3DSound are still disabled;
+# SoundPan/ChannelPan were restored in the audio-pan PR).
 # Re-enabling each builtin removes the corresponding line(s).
-samples/Blitz 2D Samples/aristoids/aristoids.bb   # SoundPan not found
-samples/Blitz 2D Samples/spider/spider.bb         # SoundPan not found
+samples/Blitz 2D Samples/aristoids/aristoids.bb   # PlayMusic not found (SoundPan now restored; PlayMusic still disabled)
 samples/Blitz 2D Samples/Celestial Rift/Celestial Rift v1-0.bb   # PlayMusic not found
 samples/Blitz 2D Samples/Celestial Rift/Celestial Rift v1-1.bb   # PlayMusic not found
 samples/Blitz 2D Samples/Project DNA/Project DNA.bb              # PlayMusic not found

--- a/src/blitzrc/bbruntime/bbaudio.cpp
+++ b/src/blitzrc/bbruntime/bbaudio.cpp
@@ -67,11 +67,11 @@ void bbSoundRange(gxSound *sound, float inNear, float inFar) {
 	sound->setRange( inNear,inFar );
 }
 
-/*void bbSoundPan( gxSound *sound,float pan ){
+void bbSoundPan( gxSound *sound,float pan ){
 	if( !sound ) return;
 	if (!debugSound( sound, "SoundPan" )) return;
 	sound->setPan( pan );
-}*/
+}
 
 gxChannel *bbPlaySound( gxSound *sound,float x,float y,float z,float vx,float vy,float vz ){
 	if( !sound ) return 0;
@@ -134,10 +134,11 @@ void bbChannelSeek(gxChannel *channel,float seconds){
     channel->setTime(seconds);
 }
 
-/*void bbChannelPan( gxChannel *channel,float pan ){
+void bbChannelPan( gxChannel *channel,float pan ){
 	if( !channel ) return;
+	if ( !gx_audio->verifyChannel(channel) ) return;
 	channel->setPan( pan );
-}*/
+}
 
 int bbChannelPlaying( gxChannel *channel ){
 	if ( !gx_audio->verifyChannel(channel) ) return 0;
@@ -164,7 +165,7 @@ void audio_link( void(*rtSym)(const char*,void*) ){
 	rtSym( "SoundPitch(BBSound)sound#pitch",bbSoundPitch );
 	rtSym( "SoundVolume(BBSound)sound#volume",bbSoundVolume );
 	rtSym( "SoundRange(BBSound)sound#near#far",bbSoundRange );
-	//rtSym( "SoundPan%sound#pan",bbSoundPan );
+	rtSym( "SoundPan(BBSound)sound#pan",bbSoundPan );
 	rtSym( "(BBChannel)PlaySound(BBSound)sound#x=NaN#y=0#z=0#vx=0#vy=0#vz=0",bbPlaySound );
 	rtSym( "StopChannel(BBChannel)channel",bbStopChannel );
 	rtSym( "PauseChannel(BBChannel)channel",bbPauseChannel );
@@ -174,7 +175,7 @@ void audio_link( void(*rtSym)(const char*,void*) ){
 	rtSym( "ChannelRange(BBChannel)channel#near#far",bbChannelRange );
 	rtSym( "ChannelPos(BBChannel)channel#x#y#z#vx=0#vy=0#vz=0",bbChannelPos );
     rtSym( "ChannelSeek(BBChannel)channel#seconds",bbChannelSeek );
-	//rtSym( "ChannelPan%channel#pan",bbChannelPan );
+	rtSym( "ChannelPan(BBChannel)channel#pan",bbChannelPan );
 	rtSym( "%ChannelPlaying(BBChannel)channel",bbChannelPlaying );
 }
 

--- a/src/blitzrc/bbruntime/bbaudio.h
+++ b/src/blitzrc/bbruntime/bbaudio.h
@@ -16,7 +16,7 @@ void		 bbLoopSound( gxSound *sound,int loop );
 void		 bbSoundPitch( gxSound *sound,float pitch );
 void		 bbSoundVolume( gxSound *sound,float volume );
 void		 bbSoundRange( gxSound *sound,float inNear,float inFar );
-//void		 bbSoundPan( gxSound *sound,float pan );
+void		 bbSoundPan( gxSound *sound,float pan );
 void		 bbStopChannel( gxChannel *channel );
 void		 bbPauseChannel( gxChannel *channel );
 void		 bbResumeChannel( gxChannel *channel );
@@ -25,7 +25,7 @@ void		 bbChannelVolume( gxChannel *channel,float volume );
 void		 bbChannelRange( gxChannel *channel,float inNear,float inFar );
 void		 bbChannelPos( gxChannel *channel,float x,float y,float z,float vx,float vy,float vz );
 void         bbChannelSeek( gxChannel *channel,float seconds );
-//void		 bbChannelPan( gxChannel *channel,float pan );
+void		 bbChannelPan( gxChannel *channel,float pan );
 int			 bbChannelPlaying( gxChannel *channel );
 
 #endif

--- a/src/blitzrc/gxruntime/gxchannel.cpp
+++ b/src/blitzrc/gxruntime/gxchannel.cpp
@@ -9,6 +9,7 @@
 #include <vorbis/vorbisfile.h>
 
 #include <chrono>
+#include <cmath>
 
 gxChannel::~gxChannel(){
 }
@@ -59,6 +60,16 @@ void SampleChannel::setVolume( float volume ){
 void SampleChannel::setRange(float inNear, float inFar) {
 	alSourcef( source,AL_REFERENCE_DISTANCE,inNear*gxAudio::posScale );
 	alSourcef( source,AL_MAX_DISTANCE,inFar*gxAudio::posScale );
+}
+
+void SampleChannel::setPan( float pan ){
+	// Stereo pan via constant-power positioning on a listener-relative source:
+	// pan -1 = full left, 0 = centre, +1 = full right. Mutually exclusive with
+	// set3d (which clears AL_SOURCE_RELATIVE) -- last call wins, matching legacy
+	// Blitz3D pan/3D semantics.
+	if( pan<-1.f ) pan=-1.f; else if( pan>1.f ) pan=1.f;
+	alSourcei( source,AL_SOURCE_RELATIVE,AL_TRUE );
+	alSource3f( source,AL_POSITION,pan,0.f,-sqrtf( 1.f-pan*pan ) );
 }
 
 void SampleChannel::set3d( const float pos[3],const float vel[3] ){
@@ -137,6 +148,12 @@ void StreamChannel::setVolume( float volume ){
 void StreamChannel::setRange(float inNear, float inFar) {
 	alSourcef( source,AL_REFERENCE_DISTANCE,inNear*gxAudio::posScale );
 	alSourcef( source,AL_MAX_DISTANCE,inFar*gxAudio::posScale );
+}
+void StreamChannel::setPan( float pan ){
+	// See SampleChannel::setPan -- constant-power pan on a relative source.
+	if( pan<-1.f ) pan=-1.f; else if( pan>1.f ) pan=1.f;
+	alSourcei( source,AL_SOURCE_RELATIVE,AL_TRUE );
+	alSource3f( source,AL_POSITION,pan,0.f,-sqrtf( 1.f-pan*pan ) );
 }
 void StreamChannel::set3d( const float pos[3],const float vel[3] ){
 	alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);

--- a/src/blitzrc/gxruntime/gxchannel.h
+++ b/src/blitzrc/gxruntime/gxchannel.h
@@ -21,6 +21,7 @@ public:
 	virtual void setPitch( float pitch )=0;
 	virtual void setVolume( float volume )=0;
 	virtual void setRange( float inNear,float inFar )=0;
+	virtual void setPan( float pan )=0;
 	virtual void set3d( const float pos[3],const float vel[3] )=0;
 	virtual void setSource( ALuint insource )=0;
     virtual void setTime( float seconds )=0;
@@ -42,6 +43,7 @@ public:
 	void setPitch( float pitch );
 	void setVolume( float volume );
 	void setRange(float inNear, float inFar);
+	void setPan( float pan );
 	void set3d( const float pos[3],const float vel[3] );
     void setTime( float seconds );
 	bool isPlaying();
@@ -64,6 +66,7 @@ public:
 	void setPitch( float pitch );
 	void setVolume( float volume );
 	void setRange(float inNear, float inFar);
+	void setPan( float pan );
 	void set3d( const float pos[3],const float vel[3] );
 	bool isPlaying();
 	bool isRelated(gxSound* snd);

--- a/src/blitzrc/gxruntime/gxsound.cpp
+++ b/src/blitzrc/gxruntime/gxsound.cpp
@@ -13,6 +13,7 @@ gxSoundSample::gxSoundSample( gxAudio *a,ALuint s ){
 	setVolume( 1.f );
 	setPitch( 1.f );
 	setRange( 100.f, 200.f );
+	setPan( 0.f );
 }
 
 gxSoundSample::~gxSoundSample(){
@@ -122,6 +123,7 @@ gxChannel *gxSoundSample::play(){
     retVal->setPitch(def_pitch);
     retVal->setVolume(def_gain);
 	retVal->setRange(def_range_near,def_range_far);
+	retVal->setPan(def_pan);
 	alSourcei(retVal->getALSource(), AL_BUFFER, sample);
 	alSourcePlay(retVal->getALSource());
 	return retVal;
@@ -160,12 +162,17 @@ void gxSoundSample::setRange(float inNear, float inFar) {
 	def_range_far=inFar;
 }
 
+void gxSoundSample::setPan( float pan ){
+	def_pan = pan;
+}
+
 gxSoundStream::gxSoundStream( gxAudio *a,bool use_3d,const std::string& name ){
 	audio=a; filename=name; is_3d=use_3d;
 	setLoop( false );
 	setVolume( 1.f );
 	setPitch( 1.f );
 	setRange( 100.f, 200.f );
+	setPan( 0.f );
 }
 
 gxSoundStream::~gxSoundStream(){
@@ -185,6 +192,7 @@ gxChannel* gxSoundStream::play() {
 	retVal->setPitch(def_pitch);
 	retVal->setVolume(def_gain);
 	retVal->setRange(def_range_near,def_range_far);
+	retVal->setPan(def_pan);
 	retVal->createThread(filename,is_3d);
 	
 	return retVal;
@@ -232,4 +240,8 @@ void gxSoundStream::setVolume( float volume ){
 void gxSoundStream::setRange(float inNear, float inFar) {
 	def_range_near=inNear;
 	def_range_far=inFar;
+}
+
+void gxSoundStream::setPan( float pan ){
+	def_pan = pan;
 }

--- a/src/blitzrc/gxruntime/gxsound.h
+++ b/src/blitzrc/gxruntime/gxsound.h
@@ -18,6 +18,7 @@ protected:
     bool def_loop;
 	float def_range_near;
 	float def_range_far;
+	float def_pan;
 	float pos[3],vel[3];
 
 	/***** GX INTERFACE *****/
@@ -31,6 +32,7 @@ public:
 	virtual void setPitch( float pitch ) =0;
 	virtual void setVolume( float volume ) =0;
 	virtual void setRange( float inNear,float inFar ) =0;
+	virtual void setPan( float pan ) =0;
 
 	//allocation
 	virtual void free() =0;
@@ -59,6 +61,7 @@ public:
 	void setPitch( float pitch );
 	void setVolume( float volume );
 	void setRange( float inNear,float inFar );
+	void setPan( float pan );
 
 	//allocation
 	static gxSoundSample* load(gxAudio *a,const std::string &filename,bool use_3d);
@@ -84,6 +87,7 @@ public:
 	void setPitch( float pitch );
 	void setVolume( float volume );
 	void setRange( float inNear,float inFar );
+	void setPan( float pan );
 
 	//allocation
 	static gxSoundStream* load(gxAudio *a,const std::string &filename,bool use_3d);

--- a/tests/AudioPanTest.bb
+++ b/tests/AudioPanTest.bb
@@ -1,0 +1,22 @@
+Strict
+EnableGC
+
+; Smoke test for the restored SoundPan / ChannelPan commands. Headless CI has no
+; audio device, so LoadSound returns Null and the pan commands no-op -- this
+; proves the symbols are registered and tolerate a Null sound/channel without
+; crashing. Audible pan correctness is verified manually on Windows (no audio
+; device in CI). The corpus sweep (aristoids.bb / spider.bb) is the compile-time
+; registration guard.
+
+Test testSoundPanChannelPanResolveAndAreNullSafe()
+	Local snd.BBSound = LoadSound( "scripts/fixtures/none.ogg" )
+	SoundPan snd, 0.5
+	SoundPan snd, -1.0
+	SoundPan snd, 2.0   ; out-of-range value must be tolerated (clamped)
+
+	Local chan.BBChannel = PlaySound( snd )
+	ChannelPan chan, -0.5
+
+	; Reached here => the commands are registered and did not crash on Null.
+	Assert( True )
+End Test


### PR DESCRIPTION
## Non-technical summary

`SoundPan` and `ChannelPan` — classic Blitz3D commands for placing a sound left/right in the stereo field — were lost when the audio backend moved from DirectSound to OpenAL, even though BlitzForge still ships their documentation and examples. Legacy games calling them failed to compile. This PR restores both commands, so those programs compile and run again (INTENT #1 drop-in compatibility, and it fixes a docs-vs-reality gap).

## Technical summary

- **`gxChannel`/`gxSound`**: added `setPan()` (pure-virtual on the bases; the only implementers are `SampleChannel`/`StreamChannel` and `gxSoundSample`/`gxSoundStream` — no macOS audio backend exists, so no stub needed).
- **Channels**: constant-power stereo pan on a listener-relative OpenAL source — clamp `pan∈[-1,1]`, `AL_SOURCE_RELATIVE=AL_TRUE`, `alSource3f(AL_POSITION, pan, 0, -sqrt(1-pan²))`. Mutually exclusive with `set3d` (last-call-wins, matching legacy pan/3D semantics).
- **Sounds**: store a default pan applied at `play()` (so `SoundPan` sets the default for subsequently-played channels).
- **`bbaudio`**: re-enabled `bbSoundPan` (`debugSound`-guarded) and `bbChannelPan` (`verifyChannel`-guarded, matching sibling channel commands) + their `rtSym` registrations, using the typed `(BBSound)`/`(BBChannel)` signatures.

No compiler/codegen/front-end change. Windows OpenAL backend only.

## Acceptance criteria + results

- [x] Build clean (0 errors); `SoundPan`/`ChannelPan` registered.
- [x] **`spider.bb` now compiles** → removed from `scripts/corpus_compile_allowlist.txt`; corpus sweep green. `aristoids.bb`'s SoundPan blocker is resolved but it *also* uses `PlayMusic` (a separate, still-disabled builtin), so it stays allowlisted with its reason updated to PlayMusic.
- [x] New `tests/AudioPanTest.bb` passes under `blitzcc -t`: the commands resolve and tolerate a Null sound/channel (incl. an out-of-range pan value) without crashing — headless-safe (no audio device in CI).
- [x] Full `test.bat` green; corpus sweep green.
- [ ] **Audible pan correctness**: not headless-verifiable (no audio device in CI). The OpenAL constant-power formula is standard and the relative-source setup is confirmed; audible verification is a manual Windows step (documented).

## Trade-offs, deferred follow-ups

- **Pure-virtual** chosen over a non-pure default (only 4 concrete implementers, all updated; forces correctness).
- **Deferred (cheap next pick, same file):** `gxSoundSample::load` short-filename crash — `LoadSound("abc")` → `substr(filename.size()-4)` underflows → `std::out_of_range` → process kill. One-line guard at `gxsound.cpp:25`.
- Other Class B builtins (`PlayMusic`/`CreateListener`/`Load3DSound`/`StartNetGame`); linker `loadImage` hardening; TCP-socket UAF; GC `reference_map` soundness; contextual-keyword Phase 2; the manual audible-pan listen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)