### PR TITLE
Bounds-check HostIP() in release mode (close an out-of-bounds read)

### DIFF
--- a/docs/notes/hostip-bounds.md
+++ b/docs/notes/hostip-bounds.md
@@ -1,0 +1,84 @@
+# Working note — Bounds-check HostIP() in release mode (close an OOB read)
+
+Branch: `fix/hostip-bounds`
+Type: Bug / Reliability (security-adjacent)
+
+## Goal (restated)
+
+`bbHostIP(int index)` (`src/blitzrc/bbruntime/bbsockets.cpp:317-324`) indexes a
+`std::vector<int>` with a BASIC-supplied index but validates it **only in debug
+mode**. In release builds (what every shipped game runs) the check is skipped and
+`host_ips[index-1]` executes unchecked: `HostIP(0)` reads `host_ips[-1]`,
+`HostIP(big)` reads far past the vector — an out-of-bounds heap read (UB) that can
+crash or leak adjacent heap bytes into a BASIC integer. This is the exact
+debug-only-guard defect class already closed for banks/streams/lists; `bbsockets.cpp`
+is the unswept remainder. INTENT #6 ("trust the runtime").
+
+## Approach
+
+Add a release-mode guard mirroring the file's sibling helpers (`debugUDPStream`
+etc.) and the bank/stream idiom: validate in BOTH modes — debug → `RTEX`, release →
+`errorLog` + `return 0` — before the dereference. Braced branches (the RTEX macro
+ends in `;`, so an unbraced `if(debug) RTEX(); else` would break — see
+[[runtime-error-guard-idiom]]).
+
+```cpp
+int bbHostIP( int index ){
+	if( index<1 || index>(int)host_ips.size() ){
+		if( debug ){
+			RTEX( "Host index out of range" );
+		} else {
+			errorLog.push_back( "HostIP: Host index out of range" );
+		}
+		return 0;
+	}
+	return host_ips[index-1];
+}
+```
+
+## Files touched
+
+- `src/blitzrc/bbruntime/bbsockets.cpp` — `bbHostIP` guard.
+- `tests/SocketTest.bb` — new; pins the bounds contract (CI-safe/offline).
+- `docs/notes/hostip-bounds.md` — this note.
+
+Windows runtime only (sockets are WSA-gated); macOS path unaffected. No ABI change.
+
+## Verification / testability
+
+Unlike audio/graphics, the socket host-IP path needs no device init, so it IS
+reachable in headless `-t` (where `debug` is false → the release/errorLog path).
+`tests/SocketTest.bb` asserts `HostIP(0)`, `HostIP(-1)`, and `HostIP(huge)` return
+0 (out-of-range, regardless of how many IPs resolved — `host_ips` may be empty in a
+hermetic CI with no resolver, which only makes every index out-of-range). Pre-fix,
+`HostIP(0)` in release/test mode is an OOB read of `host_ips[-1]`; post-fix it
+returns 0 cleanly — the regression guard.
+
+## Acceptance criteria
+
+- `HostIP(0)`, `HostIP(-1)`, `HostIP(n>CountHostIPs())` return 0 in release/test
+  mode (no OOB); raise a clean RuntimeError in debug mode.
+- Valid `HostIP(1..CountHostIPs())` path unchanged.
+- New `tests/SocketTest.bb` passes under `blitzcc -t`, offline/CI-safe.
+- `test.bat` green; corpus sweep unaffected; build 0 errors.
+
+## Trade-offs / rejected
+
+- **Rejected this iteration: contextual `Release`/`Recast`/`Reference` (Phase 2).**
+  These are PREFIX OPERATORS in `parseUniExpr` (`Release[.Type] <operand>`), unlike
+  `Test` (no expression-keyword case). Making them contextual needs
+  expression-position disambiguation (operand-follows = keyword vs operator/
+  terminator-follows = identifier) inside the unary-expression parser — M-effort,
+  real ambiguity risk, and `Release` is GC-surface. Not a clean high-confidence
+  one-iteration change. Deferred with this finding.
+- **Rejected: gxSoundSample::load short-filename crash** — real, but NOT reachable
+  in headless `-t` (audio not initialized), so no CI regression test; manual-only
+  verification. Deferred.
+
+## Deferred follow-ups
+
+- Phase 2 contextual keywords (`Release`/`Recast`/`Reference`) — needs a focused
+  feasibility pass on the parseUniExpr expression-position disambiguation.
+- `gxSoundSample::load` short-filename crash (manual-verify) + the sibling
+  filename-parsing audit (gxSoundStream missing ext validation; ddutil substr).
+- Other Class B builtins; GC reference_map soundness; manual audible-pan check.

--- a/src/blitzrc/bbruntime/bbsockets.cpp
+++ b/src/blitzrc/bbruntime/bbsockets.cpp
@@ -315,10 +315,18 @@ int bbCountHostIPs( BBStr *host ){
 }
 
 int bbHostIP( int index ){
-	if( debug ){
-		if (index<1 || index>(int)host_ips.size()){
+	// Validate in BOTH modes: in release the old code skipped the check and
+	// dereferenced host_ips[index-1] with a BASIC-supplied index -- HostIP(0)
+	// read host_ips[-1], HostIP(big) read past the vector (OOB heap read /
+	// info leak). Mirror the bank/stream guard idiom: clean RuntimeError in
+	// debug, errorLog + safe 0 in release.
+	if (index<1 || index>(int)host_ips.size()){
+		if( debug ){
 			RTEX( "Host index out of range" );
+		} else {
+			errorLog.push_back( "HostIP: Host index out of range" );
 		}
+		return 0;
 	}
 	return host_ips[index-1];
 }

--- a/tests/SocketTest.bb
+++ b/tests/SocketTest.bb
@@ -1,0 +1,25 @@
+Strict
+EnableGC
+
+; Regression test for the HostIP() out-of-bounds read. bbHostIP indexes a vector
+; with a caller-supplied index; the bounds check used to be debug-only, so a
+; release/test-mode HostIP(0) read host_ips[-1] (OOB). Now out-of-range indices
+; return 0 cleanly in both modes.
+;
+; Offline / CI-safe: it does not depend on name resolution succeeding. CountHostIPs
+; may resolve 0 addresses in a hermetic CI (no resolver), which only makes every
+; index out-of-range -- exactly what we assert. The socket host-IP path needs no
+; audio/graphics device, so unlike most gxruntime code it is reachable under -t.
+
+Test testHostIPOutOfRangeIsSafe()
+	; Populate the host-IP cache (may be empty if no resolver is available).
+	CountHostIPs( "localhost" )
+
+	; Out-of-range indices must return 0, not read out of bounds.
+	Assert( HostIP( 0 ) = 0 )
+	Assert( HostIP( -1 ) = 0 )
+	Assert( HostIP( 999999 ) = 0 )
+
+	; Reaching here proves the calls did not crash on an OOB dereference.
+	Assert( True )
+End Test


### PR DESCRIPTION
## Non-technical summary

`HostIP()` looks up a cached host IP address by index. It only checked that the index was valid in *debug* builds — so in a normal release build, `HostIP(0)` or an out-of-range index read past the end of the array (or before it), an out-of-bounds memory read that can crash or leak nearby memory into a Blitz integer. This fixes it to validate in all builds, returning 0 (and logging) for a bad index. Advances INTENT #6 ("trust the runtime").

## Technical summary

`bbHostIP(index)` in `src/blitzrc/bbruntime/bbsockets.cpp` indexed `std::vector<int> host_ips` with a BASIC-supplied index, guarded by `if(debug)` only — release skipped the check and dereferenced `host_ips[index-1]` (UB: `HostIP(0)`→`host_ips[-1]`, `HostIP(big)`→past the vector). This is the same debug-only-guard class already closed for banks (#73), ReadBytes/WriteBytes (#74/#75), and BBList; `bbsockets.cpp` was the unswept remainder. Now validated in **both** modes, mirroring the file's sibling helpers (`debugUDPStream` etc.): clean `RuntimeError` in debug, `errorLog` + `return 0` in release. Valid-index path byte-identical. Windows runtime only (WSA-gated); no ABI change.

## Acceptance criteria + results

- [x] `HostIP(0)`, `HostIP(-1)`, `HostIP(n>CountHostIPs())` return 0 (no OOB) in release/test mode; raise a clean error in debug.
- [x] Valid `HostIP(1..CountHostIPs())` unchanged.
- [x] New `tests/SocketTest.bb` passes under `blitzcc -t` — and it's genuinely CI-reachable (the host-IP path needs no audio/graphics device, unlike most gxruntime code; it's offline-safe since an empty `host_ips` just makes every index out-of-range). Pre-fix, `HostIP(0)` in test mode was an OOB read; reaching the final assert is the regression guard.
- [x] Full `test.bat` green; build 0 errors; corpus sweep unaffected.

## Trade-offs, deferred follow-ups

- **Not pile-on:** this is the first bounds/release-guard fix in 5 iterations (recent work was diagnostics, contextual-keyword, GC docs, audio) — it completes the established debug-only-guard audit on the last unswept module (sockets).
- **Deferred: contextual `Release`/`Recast`/`Reference` (legacy-compat Phase 2).** Unlike `Test`, these are *prefix operators* in `parseUniExpr` (`Release[.Type] <operand>`), so making them contextual needs expression-position disambiguation (operand-follows = keyword vs operator/terminator-follows = identifier) — M-effort with real ambiguity risk (`Release` is GC-surface). Needs a focused feasibility pass.
- **Deferred: `gxSoundSample::load` short-filename crash** — real, but not reachable in headless `-t` (audio uninitialized), so no CI regression test; manual-only.
- Other Class B builtins; GC `reference_map` soundness; manual audible-pan check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)